### PR TITLE
(feature): add ability to read and write to the Cartridge EEPROM

### DIFF
--- a/docs/ntddchgr.h
+++ b/docs/ntddchgr.h
@@ -1,0 +1,803 @@
+/*++ BUILD Version: 0001    // Increment this if a change has global effects
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Module Name:
+
+    ntddchgr.h
+
+Abstract:
+
+    This is the include file that defines all constants and types for
+    accessing medium changer devices.
+
+--*/
+
+#ifndef _NTDDCHGR_H_
+#define _NTDDCHGR_H_
+
+#include <winapifamily.h>
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#if _MSC_VER >= 1200
+#pragma warning(push)
+#pragma warning(disable:4820) /* padding added after data member */
+#endif
+
+#pragma region Desktop Family or OneCore Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+
+//
+// Device Name - this string is the name of the device.  It is the name
+// that should be passed to NtOpenFile when accessing the device.
+//
+// Note:  For devices that support multiple units, it should be suffixed
+//        with the Ascii representation of the unit number.
+//
+
+#define DD_CHANGER_DEVICE_NAME "\\Device\\Changer"
+
+//
+// NtDeviceIoControlFile IoControlCode values for changer devices.
+//
+
+
+// begin_winioctl
+
+#define IOCTL_CHANGER_BASE                FILE_DEVICE_CHANGER
+
+#define IOCTL_CHANGER_GET_PARAMETERS         CTL_CODE(IOCTL_CHANGER_BASE, 0x0000, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_GET_STATUS             CTL_CODE(IOCTL_CHANGER_BASE, 0x0001, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_GET_PRODUCT_DATA       CTL_CODE(IOCTL_CHANGER_BASE, 0x0002, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_SET_ACCESS             CTL_CODE(IOCTL_CHANGER_BASE, 0x0004, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_CHANGER_GET_ELEMENT_STATUS     CTL_CODE(IOCTL_CHANGER_BASE, 0x0005, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_CHANGER_INITIALIZE_ELEMENT_STATUS  CTL_CODE(IOCTL_CHANGER_BASE, 0x0006, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_SET_POSITION           CTL_CODE(IOCTL_CHANGER_BASE, 0x0007, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_EXCHANGE_MEDIUM        CTL_CODE(IOCTL_CHANGER_BASE, 0x0008, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_MOVE_MEDIUM            CTL_CODE(IOCTL_CHANGER_BASE, 0x0009, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_REINITIALIZE_TRANSPORT CTL_CODE(IOCTL_CHANGER_BASE, 0x000A, METHOD_BUFFERED, FILE_READ_ACCESS)
+#define IOCTL_CHANGER_QUERY_VOLUME_TAGS      CTL_CODE(IOCTL_CHANGER_BASE, 0x000B, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+
+// end_winioctl
+
+//
+// The following file contains the IOCTL_STORAGE class ioctls
+//
+
+#include <ntddstor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if _MSC_VER >= 1200
+#pragma warning(push)
+#pragma warning(disable:4820) // padding added after data member
+#endif
+
+// begin_winioctl
+
+#define MAX_VOLUME_ID_SIZE       36
+#define MAX_VOLUME_TEMPLATE_SIZE 40
+
+#define VENDOR_ID_LENGTH          8
+#define PRODUCT_ID_LENGTH        16
+#define REVISION_LENGTH           4
+#define SERIAL_NUMBER_LENGTH     32
+
+//
+// Common structures describing elements.
+//
+
+typedef  enum _ELEMENT_TYPE {
+    AllElements,        // As defined by SCSI
+    ChangerTransport,   // As defined by SCSI
+    ChangerSlot,        // As defined by SCSI
+    ChangerIEPort,      // As defined by SCSI
+    ChangerDrive,       // As defined by SCSI
+    ChangerDoor,        // Front panel, used to access internal of cabinet.
+    ChangerKeypad,      // Keypad/input on front panel.
+    ChangerMaxElement   // Placeholder only. Not a valid type.
+} ELEMENT_TYPE, *PELEMENT_TYPE;
+
+typedef  struct _CHANGER_ELEMENT {
+    ELEMENT_TYPE    ElementType;
+    ULONG   ElementAddress;
+} CHANGER_ELEMENT, *PCHANGER_ELEMENT;
+
+typedef  struct _CHANGER_ELEMENT_LIST {
+    CHANGER_ELEMENT Element;
+    ULONG   NumberOfElements;
+} CHANGER_ELEMENT_LIST , *PCHANGER_ELEMENT_LIST;
+
+
+//
+// Definitions for  IOCTL_CHANGER_GET_PARAMETERS
+//
+
+//
+// Definitions for Features0 of GET_CHANGER_PARAMETERS
+//
+
+#define CHANGER_BAR_CODE_SCANNER_INSTALLED  0x00000001 // The medium-changer has a bar code scanner installed.
+#define CHANGER_INIT_ELEM_STAT_WITH_RANGE   0x00000002 // The medium-changer has the ability to initialize elements within a specified range.
+#define CHANGER_CLOSE_IEPORT                0x00000004 // The medium-changer has the ability to close the i/e port door.
+#define CHANGER_OPEN_IEPORT                 0x00000008 // The medium-changer can open the i/e port door.
+
+#define CHANGER_STATUS_NON_VOLATILE         0x00000010 // The medium-changer uses non-volatile memory for element status information.
+#define CHANGER_EXCHANGE_MEDIA              0x00000020 // The medium-changer supports exchange operations.
+#define CHANGER_CLEANER_SLOT                0x00000040 // The medium-changer has a fixed slot designated for cleaner cartridges.
+#define CHANGER_LOCK_UNLOCK                 0x00000080 // The medium-changer can be (un)secured to (allow)prevent media removal.
+
+#define CHANGER_CARTRIDGE_MAGAZINE          0x00000100 // The medium-changer uses cartridge magazines for some storage slots.
+#define CHANGER_MEDIUM_FLIP                 0x00000200 // The medium-changer can flip medium.
+#define CHANGER_POSITION_TO_ELEMENT         0x00000400 // The medium-changer can position the transport to a particular element.
+#define CHANGER_REPORT_IEPORT_STATE         0x00000800 // The medium-changer can determine whether media is present
+                                                       // in the IE Port.
+
+#define CHANGER_STORAGE_DRIVE               0x00001000 // The medium-changer can use a drive as an independent storage element.
+#define CHANGER_STORAGE_IEPORT              0x00002000 // The medium-changer can use a i/e port as an independent storage element.
+#define CHANGER_STORAGE_SLOT                0x00004000 // The medium-changer can use a slot as an independent storage element.
+#define CHANGER_STORAGE_TRANSPORT           0x00008000 // The medium-changer can use a transport as an independent storage element.
+
+#define CHANGER_DRIVE_CLEANING_REQUIRED     0x00010000 // The drives controlled by the medium changer require periodic cleaning
+                                                       // initiated by an application.
+#define CHANGER_PREDISMOUNT_EJECT_REQUIRED  0x00020000 // The medium-changer requires a drive eject command to be issued, before a changer
+                                                       // move / exchange command can be issued to the drive.
+
+#define CHANGER_CLEANER_ACCESS_NOT_VALID    0x00040000 // The access bit in GES isn't valid for cleaner cartridges.
+#define CHANGER_PREMOUNT_EJECT_REQUIRED     0x00080000 // The medium-changer requires a drive eject command to be issued
+                                                       // before a move / exchange command can be issued with the drive as src/dst.
+
+#define CHANGER_VOLUME_IDENTIFICATION       0x00100000 // The medium-changer supports volume identification.
+#define CHANGER_VOLUME_SEARCH               0x00200000 // The medium-changer can search for volume information.
+#define CHANGER_VOLUME_ASSERT               0x00400000 // The medium-changer can verify volume information.
+#define CHANGER_VOLUME_REPLACE              0x00800000 // The medium-changer can replace volume information.
+#define CHANGER_VOLUME_UNDEFINE             0x01000000 // The medium-changer can undefine volume information.
+
+#define CHANGER_SERIAL_NUMBER_VALID         0x04000000 // The serial number reported in GetProductData is valid
+                                                       // and unique.
+
+#define CHANGER_DEVICE_REINITIALIZE_CAPABLE 0x08000000 // The medium-changer can be issued a ChangerReinitializeUnit.
+#define CHANGER_KEYPAD_ENABLE_DISABLE       0x10000000 // Indicates that the keypad can be enabled/disabled.
+#define CHANGER_DRIVE_EMPTY_ON_DOOR_ACCESS  0x20000000 // Drives must be empty before access via the door is possible.
+
+#define CHANGER_RESERVED_BIT                0x80000000 // Will be used to indicate Features1 capability bits.
+
+
+//
+// Definitions for Features1 of GET_CHANGER_PARAMETERS
+//
+
+#define CHANGER_PREDISMOUNT_ALIGN_TO_SLOT   0x80000001 // The transport must be prepositioned to the slot prior to ejecting the media.
+#define CHANGER_PREDISMOUNT_ALIGN_TO_DRIVE  0x80000002 // The transport must be prepositioned to the drive prior to ejecting the media.
+#define CHANGER_CLEANER_AUTODISMOUNT        0x80000004 // The device will move the cleaner cartridge back into the slot when cleaning has completed.
+#define CHANGER_TRUE_EXCHANGE_CAPABLE       0x80000008 // Device can do src -> dest2 exchanges.
+#define CHANGER_SLOTS_USE_TRAYS             0x80000010 // Slots have removable trays, requiring multiple moves for inject/eject.
+#define CHANGER_RTN_MEDIA_TO_ORIGINAL_ADDR  0x80000020 // Media must be returned to the slot from which it originated after a move to another element.
+#define CHANGER_CLEANER_OPS_NOT_SUPPORTED   0x80000040 // Automated cleaning operations are not supported on this device.
+#define CHANGER_IEPORT_USER_CONTROL_OPEN    0x80000080 // Indicates that user action is necessary to open a closed ieport.
+#define CHANGER_IEPORT_USER_CONTROL_CLOSE   0x80000100 // Indicates that user action is necessary to close an opened ieport.
+#define CHANGER_MOVE_EXTENDS_IEPORT         0x80000200 // Indicates that a move media to the ieport extends the tray.
+#define CHANGER_MOVE_RETRACTS_IEPORT        0x80000400 // Indicates that a move media from the ieport retracts the tray.
+
+
+//
+// Definitions for MoveFrom, ExchangeFrom, and PositionCapabilities
+//
+
+#define CHANGER_TO_TRANSPORT    0x01 // The device can carry out the operation to a transport from the specified element.
+#define CHANGER_TO_SLOT         0x02 // The device can carry out the operation to a slot from the specified element.
+#define CHANGER_TO_IEPORT       0x04 // The device can carry out the operation to an IE Port from the specified element.
+#define CHANGER_TO_DRIVE        0x08 // The device can carry out the operation to a drive from the specified element.
+
+//
+// Definitions for LockUnlockCapabilities
+//
+
+#define LOCK_UNLOCK_IEPORT      0x01 // The device can lock/unlock the ieport(s).
+#define LOCK_UNLOCK_DOOR        0x02 // The device can lock/unlock the door(s).
+#define LOCK_UNLOCK_KEYPAD      0x04 // The device can lock/unlock the keypad.
+
+typedef  struct _GET_CHANGER_PARAMETERS {
+
+    //
+    // Size of the structure. Can be used for versioning.
+    //
+
+    ULONG Size;
+
+    //
+    // Number of N element(s) as defined by the Element Address Page (or equivalent...).
+    //
+
+    USHORT NumberTransportElements;
+    USHORT NumberStorageElements;                // for data cartridges only
+    USHORT NumberCleanerSlots;                   // for cleaner cartridges
+    USHORT NumberIEElements;
+    USHORT NumberDataTransferElements;
+
+    //
+    // Number of doors/front panels (allows user entry into the cabinet).
+    //
+
+    USHORT NumberOfDoors;
+
+    //
+    // The device-specific address (from user manual of the device) of the first N element. Used
+    // by the UI to relate the various elements to the user.
+    //
+
+    USHORT FirstSlotNumber;
+    USHORT FirstDriveNumber;
+    USHORT FirstTransportNumber;
+    USHORT FirstIEPortNumber;
+    USHORT FirstCleanerSlotAddress;
+
+    //
+    // Indicates the capacity of each magazine, if they exist.
+    //
+
+    USHORT MagazineSize;
+
+    //
+    // Specifies the approximate number of seconds for when a cleaning should be completed.
+    // Only applicable if drive cleaning is supported. See Features0.
+    //
+
+    ULONG DriveCleanTimeout;
+
+    //
+    // See features bits, above.
+    //
+
+    ULONG Features0;
+    ULONG Features1;
+
+    //
+    // Bitmask defining Move from N element to element. Defined by Device Capabilities Page (or equivalent).
+    // AND-masking with the TO_XXX values will indicate legal destinations.
+    //
+
+    UCHAR MoveFromTransport;
+    UCHAR MoveFromSlot;
+    UCHAR MoveFromIePort;
+    UCHAR MoveFromDrive;
+
+    //
+    // Bitmask defining Exchange from N element to element. Defined by Device Capabilities Page (or equivalent).
+    // AND-masking with the TO_XXX values will indicate legal destinations.
+    //
+
+    UCHAR ExchangeFromTransport;
+    UCHAR ExchangeFromSlot;
+    UCHAR ExchangeFromIePort;
+    UCHAR ExchangeFromDrive;
+
+    //
+    // Bitmask defining which elements are capable of lock/unlock. Valid only if
+    // CHANGER_LOCK_UNLOCK is set in Features0.
+    //
+
+    UCHAR LockUnlockCapabilities;
+
+    //
+    // Bitmask defining which elements valid for positioning operations. Valid only if
+    // CHANGER_POSITION_TO_ELEMENT is set in Features0.
+    //
+
+    UCHAR PositionCapabilities;
+
+    //
+    // For future expansion.
+    //
+
+    UCHAR Reserved1[2];
+    ULONG Reserved2[2];
+
+} GET_CHANGER_PARAMETERS, * PGET_CHANGER_PARAMETERS;
+
+
+//
+// Definitions for IOCTL_CHANGER_GET_PRODUCT_DATA
+//
+
+typedef  struct _CHANGER_PRODUCT_DATA {
+
+    //
+    // Device manufacturer's name - based on inquiry data
+    //
+
+    UCHAR VendorId[VENDOR_ID_LENGTH];
+
+    //
+    // Product identification as defined by the vendor - based on Inquiry data
+    //
+
+    UCHAR ProductId[PRODUCT_ID_LENGTH];
+
+    //
+    // Product revision as defined by the vendor.
+    //
+
+    UCHAR Revision[REVISION_LENGTH];
+
+    //
+    // Vendor unique value used to globally identify this device. Can
+    // be from Vital Product Data, for example.
+    //
+
+    UCHAR SerialNumber[SERIAL_NUMBER_LENGTH];
+
+    //
+    // Indicates device type of data transports, as defined by SCSI-2.
+    //
+
+    UCHAR DeviceType;
+
+} CHANGER_PRODUCT_DATA, *PCHANGER_PRODUCT_DATA;
+
+
+//
+// Definitions for IOCTL_CHANGER_SET_ACCESS
+//
+
+#define LOCK_ELEMENT        0
+#define UNLOCK_ELEMENT      1
+#define EXTEND_IEPORT       2
+#define RETRACT_IEPORT      3
+
+typedef struct _CHANGER_SET_ACCESS {
+
+    //
+    // Element can be ChangerIEPort, ChangerDoor, ChangerKeypad
+    //
+
+    CHANGER_ELEMENT Element;
+
+    //
+    // See above for possible operations.
+    //
+
+    ULONG           Control;
+} CHANGER_SET_ACCESS, *PCHANGER_SET_ACCESS;
+
+
+//
+// Definitions for IOCTL_CHANGER_GET_ELEMENT_STATUS
+//
+
+//
+// Input buffer.
+//
+
+typedef struct _CHANGER_READ_ELEMENT_STATUS {
+
+    //
+    // List describing the elements and range on which to return information.
+    //
+
+    CHANGER_ELEMENT_LIST ElementList;
+
+    //
+    // Indicates whether volume tag information is to be returned.
+    //
+
+    BOOLEAN VolumeTagInfo;
+} CHANGER_READ_ELEMENT_STATUS, *PCHANGER_READ_ELEMENT_STATUS;
+
+//
+// Output buffer.
+//
+
+typedef  struct _CHANGER_ELEMENT_STATUS {
+
+    //
+    // Element to which this structure refers.
+    //
+
+    CHANGER_ELEMENT Element;
+
+    //
+    // Address of the element from which the media was originally moved.
+    // Valid if ELEMENT_STATUS_SVALID bit of Flags ULONG is set.
+    // Needs to be converted to a zero-based offset from the device-unique value.
+    //
+
+    CHANGER_ELEMENT SrcElementAddress;
+
+    //
+    // See below.
+    //
+
+    ULONG Flags;
+
+    //
+    // See below for possible values.
+    //
+
+    ULONG ExceptionCode;
+
+    //
+    // Scsi Target Id of this element.
+    // Valid only if ELEMENT_STATUS_ID_VALID is set in Flags.
+    //
+
+    UCHAR TargetId;
+
+    //
+    // LogicalUnitNumber of this element.
+    // Valid only if ELEMENT_STATUS_LUN_VALID is set in Flags.
+    //
+
+    UCHAR Lun;
+    USHORT Reserved;
+
+    //
+    // Primary volume identification for the media.
+    // Valid only if ELEMENT_STATUS_PVOLTAG bit is set in Flags.
+    //
+
+    UCHAR PrimaryVolumeID[MAX_VOLUME_ID_SIZE];
+
+    //
+    // Alternate volume identification for the media.
+    // Valid for two-sided media only, and pertains to the id. of the inverted side.
+    // Valid only if ELEMENT_STATUS_AVOLTAG bit is set in Flags.
+    //
+
+    UCHAR AlternateVolumeID[MAX_VOLUME_ID_SIZE];
+
+} CHANGER_ELEMENT_STATUS, *PCHANGER_ELEMENT_STATUS;
+
+//
+// Output buffer. This is same as CHANGER_ELEMENT_STATUS with
+// the addition of product info fields. New applications should
+// use this struct instead of the older CHANGER_ELEMENT_STATUS
+//
+
+typedef  struct _CHANGER_ELEMENT_STATUS_EX {
+
+    //
+    // Element to which this structure refers.
+    //
+
+    CHANGER_ELEMENT Element;
+
+    //
+    // Address of the element from which the media was originally moved.
+    // Valid if ELEMENT_STATUS_SVALID bit of Flags ULONG is set.
+    // Needs to be converted to a zero-based offset from the device-unique value.
+    //
+
+    CHANGER_ELEMENT SrcElementAddress;
+
+    //
+    // See below.
+    //
+
+    ULONG Flags;
+
+    //
+    // See below for possible values.
+    //
+
+    ULONG ExceptionCode;
+
+    //
+    // Scsi Target Id of this element.
+    // Valid only if ELEMENT_STATUS_ID_VALID is set in Flags.
+    //
+
+    UCHAR TargetId;
+
+    //
+    // LogicalUnitNumber of this element.
+    // Valid only if ELEMENT_STATUS_LUN_VALID is set in Flags.
+    //
+
+    UCHAR Lun;
+    USHORT Reserved;
+
+    //
+    // Primary volume identification for the media.
+    // Valid only if ELEMENT_STATUS_PVOLTAG bit is set in Flags.
+    //
+
+    UCHAR PrimaryVolumeID[MAX_VOLUME_ID_SIZE];
+
+    //
+    // Alternate volume identification for the media.
+    // Valid for two-sided media only, and pertains to the id. of the inverted side.
+    // Valid only if ELEMENT_STATUS_AVOLTAG bit is set in Flags.
+    //
+
+    UCHAR AlternateVolumeID[MAX_VOLUME_ID_SIZE];
+
+    //
+    // Vendor ID
+    //
+    UCHAR VendorIdentification[VENDOR_ID_LENGTH];
+
+    //
+    // Product ID
+    //
+    UCHAR ProductIdentification[PRODUCT_ID_LENGTH];
+
+    //
+    // Serial number
+    //
+    UCHAR SerialNumber[SERIAL_NUMBER_LENGTH];
+
+} CHANGER_ELEMENT_STATUS_EX, *PCHANGER_ELEMENT_STATUS_EX;
+
+//
+// Possible flag values
+//
+
+#define ELEMENT_STATUS_FULL      0x00000001 // Element contains a unit of media.
+#define ELEMENT_STATUS_IMPEXP    0x00000002 // Media in i/e port was placed there by an operator.
+#define ELEMENT_STATUS_EXCEPT    0x00000004 // Element is in an abnormal state; check ExceptionCode field for more information.
+#define ELEMENT_STATUS_ACCESS    0x00000008 // Access to the i/e port from the medium changer is allowed.
+#define ELEMENT_STATUS_EXENAB    0x00000010 // Export of media is supported.
+#define ELEMENT_STATUS_INENAB    0x00000020 // Import of media is supported.
+
+#define ELEMENT_STATUS_PRODUCT_DATA 0x00000040 // Serial number valid for the drive
+
+#define ELEMENT_STATUS_LUN_VALID 0x00001000 // Lun information is valid.
+#define ELEMENT_STATUS_ID_VALID  0x00002000 // SCSI Id information is valid.
+#define ELEMENT_STATUS_NOT_BUS   0x00008000 // Lun and SCSI Id fields are not on same bus as medium changer.
+#define ELEMENT_STATUS_INVERT    0x00400000 // Media in element was inverted (valid only if ELEMENT_STATUS_SVALID bit is set)
+#define ELEMENT_STATUS_SVALID    0x00800000 // SourceElementAddress field and ELEMENT_STATUS_INVERT bit are valid.
+
+#define ELEMENT_STATUS_PVOLTAG   0x10000000 // Primary volume information is valid.
+#define ELEMENT_STATUS_AVOLTAG   0x20000000 // Alternate volume information is valid.
+
+//
+// ExceptionCode values.
+//
+
+#define ERROR_LABEL_UNREADABLE    0x00000001 // Bar code scanner could not read bar code label.
+#define ERROR_LABEL_QUESTIONABLE  0x00000002 // Label could be invalid due to unit attention condition.
+#define ERROR_SLOT_NOT_PRESENT    0x00000004 // Slot is currently not addressable in the device.
+#define ERROR_DRIVE_NOT_INSTALLED 0x00000008 // Drive is not installed.
+#define ERROR_TRAY_MALFUNCTION    0x00000010 // Media tray is malfunctioning/broken.
+#define ERROR_INIT_STATUS_NEEDED  0x00000011 // An Initialize Element Status command is needed.
+#define ERROR_UNHANDLED_ERROR     0xFFFFFFFF // Unknown error condition
+
+
+//
+// Definitions for IOCTL_CHANGER_INITIALIZE_ELEMENT_STATUS
+//
+
+typedef struct _CHANGER_INITIALIZE_ELEMENT_STATUS {
+
+    //
+    // List describing the elements and range on which to initialize.
+    //
+
+    CHANGER_ELEMENT_LIST ElementList;
+
+    //
+    // Indicates whether a bar code scan should be used. Only applicable if
+    // CHANGER_BAR_CODE_SCANNER_INSTALLED is set in Features0 of CHANGER_GET_PARAMETERS.
+    //
+
+    BOOLEAN BarCodeScan;
+} CHANGER_INITIALIZE_ELEMENT_STATUS, *PCHANGER_INITIALIZE_ELEMENT_STATUS;
+
+
+//
+// Definitions for IOCTL_CHANGER_SET_POSITION
+//
+
+typedef struct _CHANGER_SET_POSITION {
+
+
+    //
+    // Indicates which transport to move.
+    //
+
+    CHANGER_ELEMENT Transport;
+
+    //
+    // Indicates the final destination of the transport.
+    //
+
+    CHANGER_ELEMENT Destination;
+
+    //
+    // Indicates whether the media currently carried by Transport, should be flipped.
+    //
+
+    BOOLEAN         Flip;
+} CHANGER_SET_POSITION, *PCHANGER_SET_POSITION;
+
+
+//
+// Definitions for IOCTL_CHANGER_EXCHANGE_MEDIUM
+//
+
+typedef struct _CHANGER_EXCHANGE_MEDIUM {
+
+    //
+    // Indicates which transport to use for the exchange operation.
+    //
+
+    CHANGER_ELEMENT Transport;
+
+    //
+    // Indicates the source for the media that is to be moved.
+    //
+
+    CHANGER_ELEMENT Source;
+
+    //
+    // Indicates the final destination of the media originally at Source.
+    //
+
+    CHANGER_ELEMENT Destination1;
+
+    //
+    // Indicates the destination of the media moved from Destination1.
+    //
+
+    CHANGER_ELEMENT Destination2;
+
+    //
+    // Indicates whether the medium should be flipped.
+    //
+
+    BOOLEAN         Flip1;
+    BOOLEAN         Flip2;
+} CHANGER_EXCHANGE_MEDIUM, *PCHANGER_EXCHANGE_MEDIUM;
+
+
+//
+// Definitions for IOCTL_CHANGER_MOVE_MEDIUM
+//
+
+typedef struct _CHANGER_MOVE_MEDIUM {
+
+    //
+    // Indicates which transport to use for the move operation.
+    //
+
+    CHANGER_ELEMENT Transport;
+
+    //
+    // Indicates the source for the media that is to be moved.
+    //
+
+    CHANGER_ELEMENT Source;
+
+    //
+    // Indicates the destination of the media originally at Source.
+    //
+
+    CHANGER_ELEMENT Destination;
+
+    //
+    // Indicates whether the media should be flipped.
+    //
+
+    BOOLEAN         Flip;
+} CHANGER_MOVE_MEDIUM, *PCHANGER_MOVE_MEDIUM;
+
+
+
+//
+// Definitions for IOCTL_QUERY_VOLUME_TAGS
+//
+
+//
+// Input buffer.
+//
+
+typedef  struct _CHANGER_SEND_VOLUME_TAG_INFORMATION {
+
+    //
+    // Describes the starting element for which to return information.
+    //
+
+    CHANGER_ELEMENT StartingElement;
+
+    //
+    // Indicates the specific action to perform. See below.
+    //
+
+    ULONG ActionCode;
+
+    //
+    // Template used by the device to search for volume ids.
+    //
+
+    UCHAR VolumeIDTemplate[MAX_VOLUME_TEMPLATE_SIZE];
+} CHANGER_SEND_VOLUME_TAG_INFORMATION, *PCHANGER_SEND_VOLUME_TAG_INFORMATION;
+
+
+//
+// Output buffer.
+//
+
+typedef struct _READ_ELEMENT_ADDRESS_INFO {
+
+    //
+    // Number of elements matching criteria set forth by ActionCode.
+    //
+
+    ULONG NumberOfElements;
+
+    //
+    // Array of CHANGER_ELEMENT_STATUS structures, one for each element that corresponded
+    // with the information passed in with the CHANGER_SEND_VOLUME_TAG_INFORMATION structure.
+    //
+
+    CHANGER_ELEMENT_STATUS ElementStatus[1];
+} READ_ELEMENT_ADDRESS_INFO, *PREAD_ELEMENT_ADDRESS_INFO;
+
+//
+// Possible ActionCode values. See Features0 of CHANGER_GET_PARAMETERS for compatibility with
+// the current device.
+//
+
+#define SEARCH_ALL         0x0 // Translate - search all defined volume tags.
+#define SEARCH_PRIMARY     0x1 // Translate - search only primary volume tags.
+#define SEARCH_ALTERNATE   0x2 // Translate - search only alternate volume tags.
+#define SEARCH_ALL_NO_SEQ  0x4 // Translate - search all defined volume tags but ignore sequence numbers.
+#define SEARCH_PRI_NO_SEQ  0x5 // Translate - search only primary volume tags but ignore sequence numbers.
+#define SEARCH_ALT_NO_SEQ  0x6 // Translate - search only alternate volume tags but ignore sequence numbers.
+
+#define ASSERT_PRIMARY     0x8 // Assert - as the primary volume tag - if tag now undefined.
+#define ASSERT_ALTERNATE   0x9 // Assert - as the alternate volume tag - if tag now undefined.
+
+#define REPLACE_PRIMARY    0xA // Replace - the primary volume tag - current tag ignored.
+#define REPLACE_ALTERNATE  0xB // Replace - the alternate volume tag - current tag ignored.
+
+#define UNDEFINE_PRIMARY   0xC // Undefine - the primary volume tag - current tag ignored.
+#define UNDEFINE_ALTERNATE 0xD // Undefine - the alternate volume tag - current tag ignored.
+
+
+//
+// Changer diagnostic test related definitions
+//
+typedef enum _CHANGER_DEVICE_PROBLEM_TYPE {
+   DeviceProblemNone,
+   DeviceProblemHardware,
+   DeviceProblemCHMError,
+   DeviceProblemDoorOpen,
+   DeviceProblemCalibrationError,
+   DeviceProblemTargetFailure,
+   DeviceProblemCHMMoveError,
+   DeviceProblemCHMZeroError,
+   DeviceProblemCartridgeInsertError,
+   DeviceProblemPositionError,
+   DeviceProblemSensorError,
+   DeviceProblemCartridgeEjectError,
+   DeviceProblemGripperError,
+   DeviceProblemDriveError
+} CHANGER_DEVICE_PROBLEM_TYPE, *PCHANGER_DEVICE_PROBLEM_TYPE;
+
+// end_winioctl
+
+#if _MSC_VER >= 1200
+#pragma warning(pop)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM) */
+#pragma endregion
+
+#if _MSC_VER >= 1200
+#pragma warning(pop)
+#endif
+
+#endif // _NTDDCHGR_H_
+

--- a/docs/ntddscsi.h
+++ b/docs/ntddscsi.h
@@ -1,0 +1,1656 @@
+/*++ BUILD Version: 0001    // Increment this if a change has global effects
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Module Name:
+
+    ntddscsi.h
+
+Abstract:
+
+    This is the include file that defines all constants and types for
+    accessing the SCSI port adapters.
+
+--*/
+
+
+//
+// Interface GUIDs
+//
+// need these GUIDs outside conditional includes so that user can
+//   #include <ntddscsi.h> in precompiled header
+//   #include <initguid.h> in a single source file
+//   #include <ntddscsi.h> in that source file a second time to instantiate the GUIDs
+//
+#ifdef DEFINE_GUID
+//
+// Make sure FAR is defined...
+//
+#ifndef FAR
+#ifdef _WIN32
+#define FAR
+#else
+#define FAR _far
+#endif
+#endif
+
+DEFINE_GUID(ScsiRawInterfaceGuid, 0x53f56309L, 0xb6bf, 0x11d0, 0x94, 0xf2, 0x00, 0xa0, 0xc9, 0x1e, 0xfb, 0x8b);
+DEFINE_GUID(WmiScsiAddressGuid,   0x53f5630fL, 0xb6bf, 0x11d0, 0x94, 0xf2, 0x00, 0xa0, 0xc9, 0x1e, 0xfb, 0x8b);
+#endif
+
+#ifndef _NTDDSCSIH_
+#define _NTDDSCSIH_
+#include <winapifamily.h>
+
+#pragma region Desktop Family or OneCore Family
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if _MSC_VER >= 1200
+#pragma warning(push)
+#pragma warning(disable:4820) /* padding added after data member */
+#endif
+
+//
+// Device Name - this string is the name of the device.  It is the name
+// that should be passed to NtOpenFile when accessing the device.
+//
+// Note:  For devices that support multiple units, it should be suffixed
+//        with the Ascii representation of the unit number.
+//
+
+#define IOCTL_SCSI_BASE                 FILE_DEVICE_CONTROLLER
+#define FILE_DEVICE_SCSI                0x0000001b
+
+#define DD_SCSI_DEVICE_NAME "\\Device\\ScsiPort"
+
+
+//
+// NtDeviceIoControlFile IoControlCode values for this device.
+//
+// Warning:  Remember that the low two bits of the code specify how the
+//           buffers are passed to the driver!
+//
+
+#define IOCTL_SCSI_PASS_THROUGH         CTL_CODE(IOCTL_SCSI_BASE, 0x0401, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_SCSI_MINIPORT             CTL_CODE(IOCTL_SCSI_BASE, 0x0402, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_SCSI_GET_INQUIRY_DATA     CTL_CODE(IOCTL_SCSI_BASE, 0x0403, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SCSI_GET_CAPABILITIES     CTL_CODE(IOCTL_SCSI_BASE, 0x0404, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SCSI_PASS_THROUGH_DIRECT  CTL_CODE(IOCTL_SCSI_BASE, 0x0405, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_SCSI_GET_ADDRESS          CTL_CODE(IOCTL_SCSI_BASE, 0x0406, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SCSI_RESCAN_BUS           CTL_CODE(IOCTL_SCSI_BASE, 0x0407, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SCSI_GET_DUMP_POINTERS    CTL_CODE(IOCTL_SCSI_BASE, 0x0408, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SCSI_FREE_DUMP_POINTERS   CTL_CODE(IOCTL_SCSI_BASE, 0x0409, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_IDE_PASS_THROUGH          CTL_CODE(IOCTL_SCSI_BASE, 0x040a, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_ATA_PASS_THROUGH          CTL_CODE(IOCTL_SCSI_BASE, 0x040b, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_ATA_PASS_THROUGH_DIRECT   CTL_CODE(IOCTL_SCSI_BASE, 0x040c, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_ATA_MINIPORT              CTL_CODE(IOCTL_SCSI_BASE, 0x040d, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_MINIPORT_PROCESS_SERVICE_IRP CTL_CODE(IOCTL_SCSI_BASE,  0x040e, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_MPIO_PASS_THROUGH_PATH    CTL_CODE(IOCTL_SCSI_BASE, 0x040f, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT CTL_CODE(IOCTL_SCSI_BASE, 0x0410, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+#define IOCTL_SCSI_PASS_THROUGH_EX          CTL_CODE(IOCTL_SCSI_BASE, 0x0411, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_SCSI_PASS_THROUGH_DIRECT_EX   CTL_CODE(IOCTL_SCSI_BASE, 0x0412, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+#define IOCTL_MPIO_PASS_THROUGH_PATH_EX         CTL_CODE(IOCTL_SCSI_BASE, 0x0413, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+#define IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT_EX  CTL_CODE(IOCTL_SCSI_BASE, 0x0414, METHOD_BUFFERED, FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+//
+// Note: Function code values of less than 0x800 are reserved for Microsoft. Values of 0x800 and higher can be used by vendors.
+//       So do not use function code of 0x800 and higher to define new IOCTLs in this file.
+//
+
+//
+// Non Volatile Cache support
+//
+
+#define IOCTL_SCSI_MINIPORT_NVCACHE           ((FILE_DEVICE_SCSI << 16) + 0x0600)
+
+//
+// Hybrid Device support
+//
+#define IOCTL_SCSI_MINIPORT_HYBRID            ((FILE_DEVICE_SCSI << 16) + 0x0620)
+
+//
+// Firmware upgrade support
+//
+#define IOCTL_SCSI_MINIPORT_FIRMWARE          ((FILE_DEVICE_SCSI << 16) + 0x0780)
+
+//
+// Diagnostic support
+//
+#define IOCTL_SCSI_MINIPORT_DIAGNOSTIC        ((FILE_DEVICE_SCSI << 16) + 0x0900)
+
+//
+// Define the SCSI pass through structure.
+//
+
+typedef struct _SCSI_PASS_THROUGH {
+    USHORT Length;
+    UCHAR ScsiStatus;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR CdbLength;
+    UCHAR SenseInfoLength;
+    UCHAR DataIn;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG_PTR DataBufferOffset;
+    ULONG SenseInfoOffset;
+    UCHAR Cdb[16];
+}SCSI_PASS_THROUGH, *PSCSI_PASS_THROUGH;
+
+//
+// Define the SCSI pass through direct structure.
+//
+
+typedef struct _SCSI_PASS_THROUGH_DIRECT {
+    USHORT Length;
+    UCHAR ScsiStatus;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR CdbLength;
+    UCHAR SenseInfoLength;
+    UCHAR DataIn;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    PVOID DataBuffer;
+    ULONG SenseInfoOffset;
+    UCHAR Cdb[16];
+}SCSI_PASS_THROUGH_DIRECT, *PSCSI_PASS_THROUGH_DIRECT;
+
+
+//
+// Define the SCSI pass through direct structure for Win64 (thunking).
+//
+#if defined(_WIN64)
+typedef struct _SCSI_PASS_THROUGH32 {
+    USHORT Length;
+    UCHAR ScsiStatus;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR CdbLength;
+    UCHAR SenseInfoLength;
+    UCHAR DataIn;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG32 DataBufferOffset;
+    ULONG SenseInfoOffset;
+    UCHAR Cdb[16];
+}SCSI_PASS_THROUGH32, *PSCSI_PASS_THROUGH32;
+
+//
+// Define the SCSI pass through direct structure.
+//
+
+typedef struct _SCSI_PASS_THROUGH_DIRECT32 {
+    USHORT Length;
+    UCHAR ScsiStatus;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR CdbLength;
+    UCHAR SenseInfoLength;
+    UCHAR DataIn;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    VOID * POINTER_32 DataBuffer;
+    ULONG SenseInfoOffset;
+    UCHAR Cdb[16];
+}SCSI_PASS_THROUGH_DIRECT32, *PSCSI_PASS_THROUGH_DIRECT32;
+
+#endif
+
+
+//
+// Data structure for IOCTL_SCSI_PASS_THROUGH_EX
+//
+
+typedef struct _SCSI_PASS_THROUGH_EX {
+    ULONG Version;
+    ULONG Length;                   // size of the structure
+    ULONG CdbLength;                // non-zero value should be set by caller
+    ULONG StorAddressLength;        // non-zero value should be set by caller
+    UCHAR ScsiStatus;
+    UCHAR SenseInfoLength;          // optional, can be zero
+    UCHAR DataDirection;            // data transfer direction
+    UCHAR Reserved;                 // padding
+    ULONG TimeOutValue;
+    ULONG StorAddressOffset;        // a value bigger than (structure size + CdbLength) should be set by caller
+    ULONG SenseInfoOffset;
+    ULONG DataOutTransferLength;    // optional, can be zero
+    ULONG DataInTransferLength;     // optional, can be zero
+    ULONG_PTR DataOutBufferOffset;
+    ULONG_PTR DataInBufferOffset;
+    _Field_size_bytes_full_(CdbLength) UCHAR Cdb[ANYSIZE_ARRAY];
+} SCSI_PASS_THROUGH_EX, *PSCSI_PASS_THROUGH_EX;
+
+
+//
+// Data structure for IOCTL_SCSI_PASS_THROUGH_DIRECT_EX
+//
+
+typedef struct _SCSI_PASS_THROUGH_DIRECT_EX {
+    ULONG Version;
+    ULONG Length;                   // size of the structure
+    ULONG CdbLength;                // non-zero value should be set by caller
+    ULONG StorAddressLength;        // non-zero value should be set by caller
+    UCHAR ScsiStatus;
+    UCHAR SenseInfoLength;          // optional, can be zero
+    UCHAR DataDirection;            // data transfer direction
+    UCHAR Reserved;                 // padding
+    ULONG TimeOutValue;
+    ULONG StorAddressOffset;        // a value bigger than (structure size + CdbLength) should be set by caller
+    ULONG SenseInfoOffset;
+    ULONG DataOutTransferLength;    // optional, can be zero
+    ULONG DataInTransferLength;     // optional, can be zero
+    _Field_size_bytes_full_(DataOutTransferLength) VOID * DataOutBuffer;
+    _Field_size_bytes_full_opt_(DataInTransferLength) VOID * DataInBuffer;
+    _Field_size_bytes_full_(CdbLength) UCHAR Cdb[ANYSIZE_ARRAY];
+} SCSI_PASS_THROUGH_DIRECT_EX, *PSCSI_PASS_THROUGH_DIRECT_EX;
+
+
+//
+// Structure needed for WOW64 support
+//
+
+#if defined(_WIN64)
+
+//
+// Data structure for IOCTL_SCSI_PASS_THROUGH_EX
+//
+
+typedef struct _SCSI_PASS_THROUGH32_EX {
+    ULONG Version;
+    ULONG Length;                   // size of the structure
+    ULONG CdbLength;                // non-zero value should be set by caller
+    ULONG StorAddressLength;        // non-zero value should be set by caller
+    UCHAR ScsiStatus;
+    UCHAR SenseInfoLength;          // optional, can be zero
+    UCHAR DataDirection;            // data transfer direction
+    UCHAR Reserved;                 // padding
+    ULONG TimeOutValue;
+    ULONG StorAddressOffset;        // a value bigger than (structure size + CdbLength) should be set by caller
+    ULONG SenseInfoOffset;
+    ULONG DataOutTransferLength;    // optional, can be zero
+    ULONG DataInTransferLength;     // optional, can be zero
+    ULONG32 DataOutBufferOffset;
+    ULONG32 DataInBufferOffset;
+    _Field_size_bytes_full_(CdbLength) UCHAR Cdb[ANYSIZE_ARRAY];
+} SCSI_PASS_THROUGH32_EX, *PSCSI_PASS_THROUGH32_EX;
+
+
+//
+// Data structure for IOCTL_SCSI_PASS_THROUGH_DIRECT_EX
+//
+
+typedef struct _SCSI_PASS_THROUGH_DIRECT32_EX {
+    ULONG Version;
+    ULONG Length;                   // size of the structure
+    ULONG CdbLength;                // non-zero value should be set by caller
+    ULONG StorAddressLength;        // non-zero value should be set by caller
+    UCHAR ScsiStatus;
+    UCHAR SenseInfoLength;          // optional, can be zero
+    UCHAR DataDirection;            // data transfer direction
+    UCHAR Reserved;                 // padding
+    ULONG TimeOutValue;
+    ULONG StorAddressOffset;        // a value bigger than (structure size + CdbLength) should be set by caller
+    ULONG SenseInfoOffset;
+    ULONG DataOutTransferLength;    // optional, can be zero
+    ULONG DataInTransferLength;     // optional, can be zero
+    _Field_size_bytes_full_(DataOutTransferLength) VOID * POINTER_32 DataOutBuffer;
+    _Field_size_bytes_full_opt_(DataInTransferLength) VOID * POINTER_32 DataInBuffer;
+    _Field_size_bytes_full_(CdbLength) UCHAR Cdb[ANYSIZE_ARRAY];
+} SCSI_PASS_THROUGH_DIRECT32_EX, *PSCSI_PASS_THROUGH_DIRECT32_EX;
+
+#endif
+
+
+//
+// ATA pass through structure
+//
+
+typedef struct _ATA_PASS_THROUGH_EX {
+    USHORT Length;
+    USHORT AtaFlags;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR ReservedAsUchar;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG ReservedAsUlong;
+    ULONG_PTR DataBufferOffset;
+    UCHAR PreviousTaskFile[8];
+    UCHAR CurrentTaskFile[8];
+} ATA_PASS_THROUGH_EX, *PATA_PASS_THROUGH_EX;
+
+//
+// ATA pass through direct structure.
+//
+
+typedef struct _ATA_PASS_THROUGH_DIRECT {
+    USHORT Length;
+    USHORT AtaFlags;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR ReservedAsUchar;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG ReservedAsUlong;
+    PVOID DataBuffer;
+    UCHAR PreviousTaskFile[8];
+    UCHAR CurrentTaskFile[8];
+} ATA_PASS_THROUGH_DIRECT, *PATA_PASS_THROUGH_DIRECT;
+
+//
+// Define the ATA pass through direct structure for Win64 (thunking).
+//
+#if defined(_WIN64)
+
+typedef struct _ATA_PASS_THROUGH_EX32 {
+    USHORT Length;
+    USHORT AtaFlags;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR ReservedAsUchar;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG ReservedAsUlong;
+    ULONG32 DataBufferOffset;
+    UCHAR PreviousTaskFile[8];
+    UCHAR CurrentTaskFile[8];
+} ATA_PASS_THROUGH_EX32, *PATA_PASS_THROUGH_EX32;
+
+//
+// ATA pass through direct structure.
+//
+
+typedef struct _ATA_PASS_THROUGH_DIRECT32 {
+    USHORT Length;
+    USHORT AtaFlags;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    UCHAR ReservedAsUchar;
+    ULONG DataTransferLength;
+    ULONG TimeOutValue;
+    ULONG ReservedAsUlong;
+    VOID * POINTER_32 DataBuffer;
+    UCHAR PreviousTaskFile[8];
+    UCHAR CurrentTaskFile[8];
+} ATA_PASS_THROUGH_DIRECT32, *PATA_PASS_THROUGH_DIRECT32;
+#endif
+
+//
+// ATA Pass Through Flags
+//
+#define ATA_FLAGS_DRDY_REQUIRED         (1 << 0)
+#define ATA_FLAGS_DATA_IN               (1 << 1)
+#define ATA_FLAGS_DATA_OUT              (1 << 2)
+#define ATA_FLAGS_48BIT_COMMAND         (1 << 3)
+#define ATA_FLAGS_USE_DMA               (1 << 4)
+#define ATA_FLAGS_NO_MULTIPLE           (1 << 5)
+
+//
+// Define header for IOCTL_ATA_MINIPORT
+//
+
+typedef struct _IDE_IO_CONTROL {
+        ULONG HeaderLength;
+        UCHAR Signature[8];
+        ULONG Timeout;
+        ULONG ControlCode;
+        ULONG ReturnStatus;
+        ULONG DataLength;
+} IDE_IO_CONTROL, *PIDE_IO_CONTROL;
+
+//
+// Define the structure for IOCTL_MPIO_PASS_THROUGH_PATH.
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH {
+        SCSI_PASS_THROUGH PassThrough;
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH, *PMPIO_PASS_THROUGH_PATH;
+
+//
+// Define the structure for IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT.
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH_DIRECT {
+        SCSI_PASS_THROUGH_DIRECT PassThrough;
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH_DIRECT, *PMPIO_PASS_THROUGH_PATH_DIRECT;
+
+//
+// Define the structure for IOCTL_MPIO_PASS_THROUGH_PATH_EX.
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH_EX {
+        ULONG   PassThroughOffset;  // Offset to a SCSI_PASS_THROUGH_EX structure.
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH_EX, *PMPIO_PASS_THROUGH_PATH_EX;
+
+//
+// Define the structure for IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT_EX.
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH_DIRECT_EX {
+        ULONG   PassThroughOffset;  // Offset to a PSCSI_PASS_THROUGH_DIRECT_EX structure.
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH_DIRECT_EX, *PMPIO_PASS_THROUGH_PATH_DIRECT_EX;
+
+//
+// Define the IOCTL_MPIO_PASS_THROUGH_PATH structure for Win64 (thunking).
+//
+
+#if defined(_WIN64)
+typedef struct _MPIO_PASS_THROUGH_PATH32 {
+        SCSI_PASS_THROUGH32 PassThrough;
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH32, *PMPIO_PASS_THROUGH_PATH32;
+
+//
+// Define the IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT structure for Win64 (thunking).
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH_DIRECT32 {
+        SCSI_PASS_THROUGH_DIRECT32 PassThrough;
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH_DIRECT32, *PMPIO_PASS_THROUGH_PATH_DIRECT32;
+
+//
+// Define the IOCTL_MPIO_PASS_THROUGH_PATH_EX structure for Win64 (thunking).
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH32_EX {
+        ULONG   PassThroughOffset;  // Offset to a PSCSI_PASS_THROUGH32_EX structure.
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH32_EX, *PMPIO_PASS_THROUGH_PATH32_EX;
+
+//
+// Define the IOCTL_MPIO_PASS_THROUGH_PATH_DIRECT_EX structure for Win64 (thunking).
+//
+
+typedef struct _MPIO_PASS_THROUGH_PATH_DIRECT32_EX {
+        ULONG   PassThroughOffset;   // Offset to a PSCSI_PASS_THROUGH_DIRECT32_EX structure.
+        ULONG   Version;
+        USHORT  Length;
+        UCHAR   Flags;
+        UCHAR   PortNumber;
+        ULONGLONG MpioPathId;
+} MPIO_PASS_THROUGH_PATH_DIRECT32_EX, *PMPIO_PASS_THROUGH_PATH_DIRECT32_EX;
+
+#endif
+
+//
+// Define SCSI information.
+// Used with the IOCTL_SCSI_GET_INQUIRY_DATA IOCTL.
+//
+
+typedef struct _SCSI_BUS_DATA {
+    UCHAR NumberOfLogicalUnits;
+    UCHAR InitiatorBusId;
+    ULONG InquiryDataOffset;
+}SCSI_BUS_DATA, *PSCSI_BUS_DATA;
+
+//
+// Define SCSI adapter bus information structure..
+// Used with the IOCTL_SCSI_GET_INQUIRY_DATA IOCTL.
+//
+
+typedef struct _SCSI_ADAPTER_BUS_INFO {
+    UCHAR NumberOfBuses;
+    SCSI_BUS_DATA BusData[1];
+} SCSI_ADAPTER_BUS_INFO, *PSCSI_ADAPTER_BUS_INFO;
+
+//
+// Define SCSI adapter bus information.
+// Used with the IOCTL_SCSI_GET_INQUIRY_DATA IOCTL.
+//
+
+typedef struct _SCSI_INQUIRY_DATA {
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+    BOOLEAN DeviceClaimed;
+    ULONG InquiryDataLength;
+    ULONG NextInquiryDataOffset;
+    UCHAR InquiryData[1];
+}SCSI_INQUIRY_DATA, *PSCSI_INQUIRY_DATA;
+
+//
+// Define header for I/O control SRB.
+//
+
+//
+// Acceptable signatures for SCSI IOCTL MINIPORT calls. Must be equal in byte size to sizeof(SrbIoctl->Signature)
+//
+#define IOCTL_MINIPORT_SIGNATURE_SCSIDISK           "SCSIDISK"
+#define IOCTL_MINIPORT_SIGNATURE_HYBRDISK           "HYBRDISK"
+#define IOCTL_MINIPORT_SIGNATURE_DSM_NOTIFICATION   "MPDSM   "
+#define IOCTL_MINIPORT_SIGNATURE_DSM_GENERAL        "MPDSMGEN"
+
+#define IOCTL_MINIPORT_SIGNATURE_FIRMWARE           "FIRMWARE"
+#define IOCTL_MINIPORT_SIGNATURE_QUERY_PROTOCOL     "PROTOCOL"
+#define IOCTL_MINIPORT_SIGNATURE_SET_PROTOCOL       "SETPROTO"
+#define IOCTL_MINIPORT_SIGNATURE_QUERY_TEMPERATURE  "TEMPERAT"
+#define IOCTL_MINIPORT_SIGNATURE_SET_TEMPERATURE_THRESHOLD  "SETTEMPT"
+#define IOCTL_MINIPORT_SIGNATURE_QUERY_PHYSICAL_TOPOLOGY    "TOPOLOGY"
+#define IOCTL_MINIPORT_SIGNATURE_ENDURANCE_INFO     "ENDURINF"
+
+
+typedef struct _SRB_IO_CONTROL {
+        ULONG HeaderLength;
+        UCHAR Signature[8];
+        ULONG Timeout;
+        ULONG ControlCode;
+        ULONG ReturnCode;
+        ULONG Length;
+} SRB_IO_CONTROL, *PSRB_IO_CONTROL;
+
+typedef struct _NVCACHE_REQUEST_BLOCK {
+    ULONG           NRBSize;
+    USHORT          Function;
+    ULONG           NRBFlags;
+    ULONG           NRBStatus;
+    ULONG           Count;
+    ULONGLONG       LBA;
+    ULONG           DataBufSize;
+    ULONG           NVCacheStatus;
+    ULONG           NVCacheSubStatus;
+} NVCACHE_REQUEST_BLOCK, *PNVCACHE_REQUEST_BLOCK;
+
+#define NRB_FUNCTION_NVCACHE_INFO               0xEC
+#define NRB_FUNCTION_SPINDLE_STATUS                 0xE5
+#define NRB_FUNCTION_NVCACHE_POWER_MODE_SET         0x00
+#define NRB_FUNCTION_NVCACHE_POWER_MODE_RETURN  0x01
+#define NRB_FUNCTION_FLUSH_NVCACHE              0x14
+#define NRB_FUNCTION_QUERY_PINNED_SET           0x12
+#define NRB_FUNCTION_QUERY_CACHE_MISS           0x13
+#define NRB_FUNCTION_ADD_LBAS_PINNED_SET        0x10
+#define NRB_FUNCTION_REMOVE_LBAS_PINNED_SET     0x11
+#define NRB_FUNCTION_QUERY_ASCENDER_STATUS      0xD0
+#define NRB_FUNCTION_QUERY_HYBRID_DISK_STATUS   0xD1
+
+//
+// The NRB function - NRB_FUNCTION_PASS_HINT_PAYLOAD is deprecated.
+//
+#define NRB_FUNCTION_PASS_HINT_PAYLOAD          0xE0
+
+//
+// Function set to control write back caching policy separated non volatile cache in the miniport
+//
+#define NRB_FUNCTION_NVSEPARATED_INFO              0xc0
+#define NRB_FUNCTION_NVSEPARATED_FLUSH             0xc1
+#define NRB_FUNCTION_NVSEPARATED_WB_DISABLE        0xc2
+#define NRB_FUNCTION_NVSEPARATED_WB_REVERT_DEFAULT 0xc3
+
+
+#define NRB_SUCCESS                             0
+#define NRB_ILLEGAL_REQUEST                     1
+#define NRB_INVALID_PARAMETER                   2
+#define NRB_INPUT_DATA_OVERRUN                  3
+#define NRB_INPUT_DATA_UNDERRUN                 4
+#define NRB_OUTPUT_DATA_OVERRUN                 5
+#define NRB_OUTPUT_DATA_UNDERRUN                6
+
+typedef struct _NV_FEATURE_PARAMETER{
+        USHORT NVPowerModeEnabled;
+        USHORT NVParameterReserv1;
+        USHORT NVCmdEnabled;
+        USHORT NVParameterReserv2;
+        USHORT NVPowerModeVer;
+        USHORT NVCmdVer;
+        ULONG  NVSize;               // in number of LBA
+        USHORT NVReadSpeed;          // in MB/s
+        USHORT NVWrtSpeed;
+        ULONG  DeviceSpinUpTime;             // in second
+} NV_FEATURE_PARAMETER, *PNV_FEATURE_PARAMETER;
+
+#pragma warning(push)
+#pragma warning(disable:4214) // bit fields other than int
+#pragma warning(disable:4201) // nameless struct/unions
+
+//
+// NOTE that data structure NVCACHE_HINT_PAYLOAD is deprecated along with NRB function - NRB_FUNCTION_PASS_HINT_PAYLOAD.
+//
+// Parameter structure for NRB_FUNCTION_PASS_HINT_PAYLOAD request
+// This is the corresponding data structure for FIS 0x27 defined in SATA-IO spec.
+// Caller that prepares this data structure shall set '0' to any non-used data field.
+//
+#pragma pack(push, nvcachehintpayload, 1)
+typedef struct _NVCACHE_HINT_PAYLOAD {
+    UCHAR Command;              // 0x63 or 0x64
+    UCHAR Feature7_0;           // when Commmand is 0x63, bit 0 - 3 reflects SubCommand
+    UCHAR Feature15_8;
+    UCHAR Count15_8;            // when Commmand is 0x64, bit 0 - 4 reflects SubCommand
+
+    UCHAR LBA7_0;
+    UCHAR LBA15_8;
+    UCHAR LBA23_16;
+    UCHAR LBA31_24;
+
+    UCHAR LBA39_32;
+    UCHAR LBA47_40;
+    UCHAR Auxiliary7_0;
+    UCHAR Auxiliary23_16;
+    
+    UCHAR Reserved[4];
+} NVCACHE_HINT_PAYLOAD, *PNVCACHE_HINT_PAYLOAD;
+#pragma pack(pop, nvcachehintpayload)
+
+//
+// Parameter structure for NRB_FUNCTION_NVSEPARATED_INFO request
+//
+// Describes parameters of non volatile cache, supported by the miniport (aka separated nv cache).
+//
+// Caching is associated with the logical unit, it is up to the miniport to implement the exact scope (adapter or unit). MP caching  is relative
+// to what miniport considers as primary non volatile media for the unit. Miniport caching layer  is separate from the caching layer integrated
+// on the device and managed by the specific NRB functions. Miniport may have to support both separated cache and on device cache as well
+// as volatile caches. Volatile cache policy is queried through the StorageProperty interface.
+//
+// Note that owner of the caching  policy may be miniport or the HBA firmware, in either case miniport is the handler of the policy setting.
+//
+
+typedef struct _NV_SEP_CACHE_PARAMETER{
+        ULONG   Version;                // Version of the request structure
+        ULONG   Size;                   // Size of this structure in bytes
+
+        union {
+
+            struct {
+                //
+                // Capability flags, describing separated non volatile cache
+                //
+                UCHAR   WriteCacheEnabled   : 1;   // Is write caching enabled by the miniport as a persistent policy
+                UCHAR   WriteCacheChangeable: 1;   // Does the miniport respect change in write caching policy
+                UCHAR   WriteThroughIOSupported :1;// Does the miniport support WriteThrough semantics for the NV cache on individual Writes .
+                UCHAR   FlushCacheSupported :1;    // Does the miniport support flushing of the NV cache
+                UCHAR   ReservedBits: 4;
+            }   CacheFlags;
+
+            UCHAR   CacheFlagsSet;
+        } Flags;
+
+        //
+        // Persistent (cross boot) and effective caching types
+        //
+        UCHAR   WriteCacheType;         // Type of the NV cache (policy) supported by the miniport - persistent setting.
+        UCHAR   WriteCacheTypeEffective;// Effective type of the NV cache (policy) used by the miniport at the time of query.
+
+        UCHAR   ParameterReserve1[3];
+} NV_SEP_CACHE_PARAMETER, *PNV_SEP_CACHE_PARAMETER;
+
+//
+// Define version value for the structure
+//
+#define NV_SEP_CACHE_PARAMETER_VERSION_1        1
+#define NV_SEP_CACHE_PARAMETER_VERSION          NV_SEP_CACHE_PARAMETER_VERSION_1
+
+//
+// Caching policy for separated NV cache.
+//
+// There are 2 distinct settings fields, one describing policy as used by the miniport
+// after boot. The other field describes current effective policy setting, which may be impacted by NRB_FUNCTION_NVSEPARATED_WB_DISABLE
+//
+// Caller of NRB_FUNCTION_NVSEPARATED_INFO should expect only the effective policy setting to be modified if the query is made after
+// call to NRB_FUNCTION_NVSEPARATED_WB_DISABLE (or other control codes in the future).
+//
+// Control of the persistent policy setting (WriteCacheType) is performed only through miniport proprietary interfaces
+//
+
+typedef enum _NV_SEP_WRITE_CACHE_TYPE    {
+    NVSEPWriteCacheTypeUnknown    = 0,       // Miniport can't report the type of the write cache
+    NVSEPWriteCacheTypeNone      = 1,        // Miniport doesn't support non volatile write cache
+    NVSEPWriteCacheTypeWriteBack = 2,        // Miniport supports write back caching
+    NVSEPWriteCacheTypeWriteThrough = 3      // Miniport supports write through caching
+} NV_SEP_WRITE_CACHE_TYPE, *PNV_SEP_WRITE_CACHE_TYPE;
+
+#pragma warning(pop)
+
+//
+// STORAGE_DIAGNOSTIC_STATUS definitions
+//
+#define STORAGE_DIAGNOSTIC_STATUS_SUCCESS                              0
+#define STORAGE_DIAGNOSTIC_STATUS_BUFFER_TOO_SMALL                     0x1
+#define STORAGE_DIAGNOSTIC_STATUS_UNSUPPORTED_VERSION                  0x2
+#define STORAGE_DIAGNOSTIC_STATUS_INVALID_PARAMETER                    0x3
+#define STORAGE_DIAGNOSTIC_STATUS_INVALID_SIGNATURE                    0x4
+#define STORAGE_DIAGNOSTIC_STATUS_INVALID_TARGET_TYPE                  0x5
+#define STORAGE_DIAGNOSTIC_STATUS_MORE_DATA                            0x6
+
+//
+// Diagnostic level allow caller to control what kinds of data the provider should return.
+//
+// Currently there is only default level defined, provider makes the call to return
+// anything it assumes helpful for diagnostic purpose.
+//
+typedef enum _MP_STORAGE_DIAGNOSTIC_LEVEL {
+    MpStorageDiagnosticLevelDefault = 0,
+    MpStorageDiagnosticLevelMax
+} MP_STORAGE_DIAGNOSTIC_LEVEL, *PMP_STORAGE_DIAGNOSTIC_LEVEL;
+
+typedef enum _MP_STORAGE_DIAGNOSTIC_TARGET_TYPE {
+
+    MpStorageDiagnosticTargetTypeUndefined = 0,
+    MpStorageDiagnosticTargetTypeMiniport = 2,
+    MpStorageDiagnosticTargetTypeHbaFirmware,
+    MpStorageDiagnosticTargetTypeMax
+
+} MP_STORAGE_DIAGNOSTIC_TARGET_TYPE, *PMP_STORAGE_DIAGNOSTIC_TARGET_TYPE;
+
+//
+// IOCTL_SCSI_MINIPORT_DIAGNOSTIC
+//
+// Diagnostic request to Miniport
+//
+
+//
+// Parameter for STORAGE_DIAGNOSTIC_MP_REQUEST
+// Input buffer should contain SRB_IO_CONTROL, STORAGE_DIAGNOSTIC_MP_REQUEST structures.
+// 
+// Fields in STORAGE_DIAGNOSTIC_MP_REQUEST
+// - Input: Version
+// - Input: TargetType
+// - Input: Level
+// - Output: ProviderId
+// - Input/Output: BufferSize
+//     As input:
+//       "BufferSize" should be set to number of bytes allocated for the DataBuffer.
+//     As output: 
+//       If the request is failed because of buffer too short, "BufferSize" should be set to the
+//       length required for DataBuffer by the diagnostic data provider;
+//       If the request is successful, it should be filled with returned data size of DataBuffer;
+//       For other cases, it should be cleared to 0.
+// - Output: DataBuffer
+//
+
+typedef struct _STORAGE_DIAGNOSTIC_MP_REQUEST {
+
+    // Size of this structure.
+    ULONG Version;
+
+    // Whole size of the structure and the associated data buffer.
+    ULONG Size;
+
+    // Request target type.
+    MP_STORAGE_DIAGNOSTIC_TARGET_TYPE TargetType;
+
+    // Diagnostic level.
+    MP_STORAGE_DIAGNOSTIC_LEVEL Level;
+
+    // GUID of diagnostic data provider.
+    GUID ProviderId;
+
+    // Data buffer size.
+    ULONG BufferSize;
+
+    // Reserved for future use.
+    ULONG Reserved;
+
+    // Diagnostic data buffer.
+    _Field_size_(BufferSize) UCHAR DataBuffer[ANYSIZE_ARRAY];
+
+} STORAGE_DIAGNOSTIC_MP_REQUEST, *PSTORAGE_DIAGNOSTIC_MP_REQUEST;
+
+//
+// MINIPORT_IOCTL block for data set management notifications
+//
+// Structure used to describe the list of ranges to process, should match the one in ntddstor.h
+//
+
+typedef struct _MP_DEVICE_DATA_SET_RANGE {
+    LONGLONG    StartingOffset;         // Measured in bytes,  must align to a sector boundary
+    ULONGLONG   LengthInBytes;          // Multiple of sector size.
+} MP_DEVICE_DATA_SET_RANGE, *PMP_DEVICE_DATA_SET_RANGE;
+
+
+typedef struct _DSM_NOTIFICATION_REQUEST_BLOCK {
+        ULONG   Size;                   // Length of this structure
+        ULONG   Version;                // Version of the template
+
+        ULONG   NotifyFlags;            // Same as in DSM definitions (eg Begin, End)
+        ULONG   DataSetProfile;         // Expected profile of IO access (based on OS file type : eg, hibernation, crashdump)
+        ULONG   Reserved[3];            // Reserved for future use
+        ULONG   DataSetRangesCount;
+        MP_DEVICE_DATA_SET_RANGE DataSetRanges[ANYSIZE_ARRAY];
+} DSM_NOTIFICATION_REQUEST_BLOCK,*PDSM_NOTIFICATION_REQUEST_BLOCK;
+
+//
+// Define version value for the structure
+//
+#define MINIPORT_DSM_NOTIFICATION_VERSION_1     1
+#define MINIPORT_DSM_NOTIFICATION_VERSION       MINIPORT_DSM_NOTIFICATION_VERSION_1
+
+//
+// Define access profiles, which are passed to the miniport, as describing expected access pattern to the dataset
+//
+#define MINIPORT_DSM_PROFILE_UNKNOWN    0
+#define MINIPORT_DSM_PROFILE_PAGE_FILE  1
+#define MINIPORT_DSM_PROFILE_HIBERNATION_FILE   2
+#define MINIPORT_DSM_PROFILE_CRASHDUMP_FILE     3
+
+//
+// Notification flag values  - consistent with DSM flags, defined in ntddstor.h
+//
+#define MINIPORT_DSM_NOTIFY_FLAG_BEGIN            0x00000001  // The given LBA range is being used as defined by the profileID
+#define MINIPORT_DSM_NOTIFY_FLAG_END              0x00000002  // The given LBA range is no longer being used as defined by the proileID
+
+
+//
+// Data structure and definitions related to IOCTL_SCSI_MINIPORT_HYBRID
+//
+
+#define HYBRID_FUNCTION_GET_INFO                            0x01
+
+#define HYBRID_FUNCTION_DISABLE_CACHING_MEDIUM              0x10
+#define HYBRID_FUNCTION_ENABLE_CACHING_MEDIUM               0x11
+#define HYBRID_FUNCTION_SET_DIRTY_THRESHOLD                 0x12
+#define HYBRID_FUNCTION_DEMOTE_BY_SIZE                      0x13
+
+//
+// HYBRID IOCTL status
+//
+#define HYBRID_STATUS_SUCCESS                             0x0
+#define HYBRID_STATUS_ILLEGAL_REQUEST                     0x1
+#define HYBRID_STATUS_INVALID_PARAMETER                   0x2
+#define HYBRID_STATUS_OUTPUT_BUFFER_TOO_SMALL             0x3
+
+//
+// A driver should keep a "RefCount" for HYBRID_FUNCTION_ENABLE_CACHING_MEDIUM.
+// e.g. it increases this value every time when it receives a HYBRID_FUNCTION_ENABLE_CACHING_MEDIUM call.
+// 
+// When driver receives HYBRID_FUNCTION_DISABLE_CACHING_MEDIUM call, it decreases "RefCount" when it's bigger than 0, 
+// and then only send command to disable caching medium when the new "RefCount" value is 0.
+// 
+// In case of HYBRID_FUNCTION_DISABLE_CACHING_MEDIUM is received but no command is sent to device because of decreased "RefCount" is not 0,
+// the driver returns following status to inform caller.
+//
+#define HYBRID_STATUS_ENABLE_REFCOUNT_HOLD                0x10
+
+//
+// General input data structure.
+// Any data structures in input buffer after SRB_IO_CONTROL should contain HYBRID_REQUEST_BLOCK.
+//
+#define HYBRID_REQUEST_BLOCK_STRUCTURE_VERSION          0x1
+
+typedef struct _HYBRID_REQUEST_BLOCK {
+    ULONG   Version;            // HYBRID_REQUEST_BLOCK_STRUCTURE_VERSION
+    ULONG   Size;               // Size of the data structure.
+    ULONG   Function;           // Function code
+    ULONG   Flags;
+
+    ULONG   DataBufferOffset;   // the offset is from the beginning of buffer. e.g. from beginning of SRB_IO_CONTROL. The value should be multiple of sizeof(PVOID); Value 0 means that there is no data buffer.
+    ULONG   DataBufferLength;   // length of the buffer
+} HYBRID_REQUEST_BLOCK, *PHYBRID_REQUEST_BLOCK;
+
+//
+// Parameter for HYBRID_FUNCTION_GET_INFO
+// Input buffer should contain SRB_IO_CONTROL and HYBRID_REQUEST_BLOCK data structures.
+// Field "DataBufferOffset" of HYBRID_REQUEST_BLOCK points to output data buffer and HYBRID_INFORMATION should be returned.
+//
+
+//
+// Output parameter for HYBRID_FUNCTION_GET_INFO
+//
+typedef enum _NVCACHE_TYPE {
+    NvCacheTypeUnknown        = 0,  // Driver can't report the type of the nvcache
+    NvCacheTypeNone           = 1,  // Device doesn't support non-volatile cache
+    NvCacheTypeWriteBack      = 2,  // Device supports write back caching
+    NvCacheTypeWriteThrough   = 3   // Device supports write through caching
+} NVCACHE_TYPE;
+
+typedef enum _NVCACHE_STATUS {
+    NvCacheStatusUnknown     = 0,   // Driver can't report non-volatile cache status
+    NvCacheStatusDisabling   = 1,   // non-volatile cache is in process of being disabled.
+    NvCacheStatusDisabled    = 2,   // non-volatile cache has been disabled.
+    NvCacheStatusEnabled     = 3    // non-volatile cache has been enabled.
+} NVCACHE_STATUS;
+
+typedef struct _NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
+    UCHAR   PriorityLevel;
+    UCHAR   Reserved0[3];
+    ULONG   ConsumedNVMSizeFraction;
+    ULONG   ConsumedMappingResourcesFraction;
+    ULONG   ConsumedNVMSizeForDirtyDataFraction;
+    ULONG   ConsumedMappingResourcesForDirtyDataFraction;
+    ULONG   Reserved1;
+} NVCACHE_PRIORITY_LEVEL_DESCRIPTOR, *PNVCACHE_PRIORITY_LEVEL_DESCRIPTOR;
+
+#define HYBRID_REQUEST_INFO_STRUCTURE_VERSION           0x1
+
+#pragma warning(push)
+#pragma warning(disable:4214) // bit fields other than int
+#pragma warning(disable:4200) // nonstandard extension used : zero-sized array in struct/union
+
+typedef struct _HYBRID_INFORMATION {
+    ULONG           Version;                // HYBRID_REQUEST_INFO_STRUCTURE_VERSION
+    ULONG           Size;                   // sizeof(HYBRID_INFORMATION)
+
+    BOOLEAN         HybridSupported;
+    NVCACHE_STATUS  Status;                 // for hybrid disk, expect values can be: NvCacheStatusDisabling, NvCacheStatusDisabled or NvCacheStatusEnabled
+    NVCACHE_TYPE    CacheTypeEffective;     // for hybrid disk, expect value will be: NvCacheTypeWriteBack
+    NVCACHE_TYPE    CacheTypeDefault;       // for hybrid disk, expect values can be: NvCacheTypeWriteBack
+
+    ULONG           FractionBase;           // Base value of all fraction type of fields in the data structure. For hybrid disk, value of this field will be 255.
+
+    ULONGLONG       CacheSize;              // total size of NVCache. unit: LBA count
+
+    struct {
+        ULONG   WriteCacheChangeable    : 1;    // Does the device respect change in write caching policy
+        ULONG   WriteThroughIoSupported : 1;    // Does the device support WriteThrough semantics for the NVCache on individual Writes.
+        ULONG   FlushCacheSupported     : 1;    // Does the device support flushing of the NVCache
+        ULONG   Removable               : 1;    // Does the nvcache can be removed.
+        ULONG   ReservedBits            : 28;
+    } Attributes;
+
+    struct {
+        UCHAR     PriorityLevelCount;           // A non-zero value indicates the non-volatile cache supports priority levels.
+        BOOLEAN   MaxPriorityBehavior;          // If set to TRUE, the disk may fail IO sent with max priority level when it cannot find space for the IO in caching medium.
+        UCHAR     OptimalWriteGranularity;      // In LBAs. Value is the power value (of 2). Value 0xFF means that Optimal Write Granularity is not indicated. 
+                                                //          For example: value 0 indicates 2^0 = 1 logical sector, 1 indicates 2^1 = 2 logical sectors
+        UCHAR     Reserved;
+
+        ULONG     DirtyThresholdLow;            // fraction type of value, with base "FractionBase".
+        ULONG     DirtyThresholdHigh;           // fraction type of value, with base "FractionBase".
+
+        struct {
+            ULONG   CacheDisable                : 1;    // support of disabling the caching medium
+            ULONG   SetDirtyThreshold           : 1;    // support of Setting dirty threshold for the entire caching medium
+            ULONG   PriorityDemoteBySize        : 1;    // support of demote by size command
+            ULONG   PriorityChangeByLbaRange    : 1;    // support of change by lba command
+            ULONG   Evict                       : 1;    // support of evict command
+            ULONG   ReservedBits                : 27;
+
+            ULONG   MaxEvictCommands;                   // Max outstanding Evict commands concurrently. Only value when "Evict" value is 1.
+
+            ULONG   MaxLbaRangeCountForEvict;           // Count of LBA ranges can be associated with evict command. Only value when "Evict" value is 1.
+            ULONG   MaxLbaRangeCountForChangeLba;       // Count of LBA ranges associated with PriorityChangeByLbaRange command. Only value when "PriorityChangeByLbaRange" value is 1.
+        } SupportedCommands;
+
+        NVCACHE_PRIORITY_LEVEL_DESCRIPTOR   Priority[0];
+
+    } Priorities;
+
+} HYBRID_INFORMATION, *PHYBRID_INFORMATION;
+
+#pragma warning(pop)
+
+//
+// Parameter for HYBRID_FUNCTION_DISABLE_CACHING_MEDIUM and HYBRID_FUNCTION_ENABLE_CACHING_MEDIUM
+// Input buffer should contain SRB_IO_CONTROL and HYBRID_REQUEST_BLOCK data structures.
+// Field "DataBufferOffset" of HYBRID_REQUEST_BLOCK should be set to "0" indicating there is no other parameter associated.
+// NOTE that these functions don't have output parameter.
+//
+
+
+//
+// Parameter for HYBRID_FUNCTION_SET_DIRTY_THRESHOLD
+// Input buffer should contain SRB_IO_CONTROL, HYBRID_REQUEST_BLOCK and HYBRID_DIRTY_THRESHOLDS data structures.
+// Field "DataBufferOffset" of HYBRID_REQUEST_BLOCK should be set to the starting offset of HYBRID_DIRTY_THRESHOLDS from beginning of buffer.
+// NOTE that these functions don't have output parameter.
+//
+typedef struct _HYBRID_DIRTY_THRESHOLDS {
+    ULONG   Version;
+    ULONG   Size;               // sizeof(HYBRID_DIRTY_THRESHOLDS)
+
+    ULONG   DirtyLowThreshold;  //
+    ULONG   DirtyHighThreshold; // >= DirtyLowThreshold 
+} HYBRID_DIRTY_THRESHOLDS, *PHYBRID_DIRTY_THRESHOLDS;
+
+//
+// Parameter for HYBRID_FUNCTION_DEMOTE_BY_SIZE
+// Input buffer should contain SRB_IO_CONTROL, HYBRID_REQUEST_BLOCK and HYBRID_DEMOTE_BY_SIZE data structures.
+// Field "DataBufferOffset" of HYBRID_REQUEST_BLOCK should be set to the starting offset of HYBRID_DEMOTE_BY_SIZE from beginning of buffer.
+// NOTE that these functions don't have output parameter.
+//
+typedef struct _HYBRID_DEMOTE_BY_SIZE {
+    ULONG       Version;
+    ULONG       Size;               // sizeof(HYBRID_DEMOTE_BY_SIZE)
+
+    UCHAR       SourcePriority;     // 1 ~ max priority
+    UCHAR       TargetPriority;     // < SourcePriority
+    USHORT      Reserved0;
+    ULONG       Reserved1;
+    ULONGLONG   LbaCount;           // How many LBAs should be demoted 
+} HYBRID_DEMOTE_BY_SIZE, *PHYBRID_DEMOTE_BY_SIZE;
+
+
+
+//
+// Data structure and definitions related to IOCTL_SCSI_MINIPORT_FIRMWARE
+//
+
+#define FIRMWARE_FUNCTION_GET_INFO                          0x01
+#define FIRMWARE_FUNCTION_DOWNLOAD                          0x02
+#define FIRMWARE_FUNCTION_ACTIVATE                          0x03
+
+//
+// FIRMWARE IOCTL status
+//
+#define FIRMWARE_STATUS_SUCCESS                             0x0
+#define FIRMWARE_STATUS_ERROR                               0x1
+#define FIRMWARE_STATUS_ILLEGAL_REQUEST                     0x2
+#define FIRMWARE_STATUS_INVALID_PARAMETER                   0x3
+#define FIRMWARE_STATUS_INPUT_BUFFER_TOO_BIG                0x4
+#define FIRMWARE_STATUS_OUTPUT_BUFFER_TOO_SMALL             0x5
+#define FIRMWARE_STATUS_INVALID_SLOT                        0x6
+#define FIRMWARE_STATUS_INVALID_IMAGE                       0x7
+#define FIRMWARE_STATUS_CONTROLLER_ERROR                    0x10
+#define FIRMWARE_STATUS_POWER_CYCLE_REQUIRED                0x20
+#define FIRMWARE_STATUS_DEVICE_ERROR                        0x40
+#define FIRMWARE_STATUS_INTERFACE_CRC_ERROR                 0x80
+#define FIRMWARE_STATUS_UNCORRECTABLE_DATA_ERROR            0x81
+#define FIRMWARE_STATUS_MEDIA_CHANGE                        0x82
+#define FIRMWARE_STATUS_ID_NOT_FOUND                        0x83
+#define FIRMWARE_STATUS_MEDIA_CHANGE_REQUEST                0x84
+#define FIRMWARE_STATUS_COMMAND_ABORT                       0x85
+#define FIRMWARE_STATUS_END_OF_MEDIA                        0x86
+#define FIRMWARE_STATUS_ILLEGAL_LENGTH                      0x87
+
+//
+// For IOCTL_SCSI_MINIPORT_FIRMWARE, the data buffer should contain following structures/fields:
+// 1. SRB_IO_CONTROL
+//    This is the header data structure indicating which IOCTL is sent. In this case, it's IOCTL_SCSI_MINIPORT_FIRMWARE.
+// 2. FIRMWARE_REQUEST_BLOCK
+//    This data structure shall be right after SRB_IO_CONTROL. It indicates:
+//    a: the function code of firmware request.
+//    b: the data buffer location (in field - DataBufferOffset) and length (in field - DataBufferLength) for the firmware function.
+//       DataBufferOffset: should have value: ALIGN_UP(sizeof(SRB_IO_CONTROL) + sizeof(FIRMWARE_REQUEST_BLOCK), PVOID). This is to make sure the buffer is pointer aligned.
+// 3. Padding. In case of (sizeof(SRB_IO_CONTROL) + sizeof(FIRMWARE_REQUEST_BLOCK)) is not multiple of pointer size, there will be padding space.
+// 4. STORAGE_FIRMWARE_INFO or STORAGE_FIRMWARE_DOWNLOAD or STORAGE_FIRMWARE_ACTIVATE depending on the function code of firmware request.
+//
+#define FIRMWARE_REQUEST_BLOCK_STRUCTURE_VERSION            0x1
+
+typedef struct _FIRMWARE_REQUEST_BLOCK {
+    ULONG   Version;            // FIRMWARE_REQUEST_BLOCK_STRUCTURE_VERSION
+    ULONG   Size;               // Size of the data structure.
+    ULONG   Function;           // Function code
+    ULONG   Flags;
+
+    ULONG   DataBufferOffset;   // the offset is from the beginning of buffer. e.g. from beginning of SRB_IO_CONTROL. The value should be multiple of sizeof(PVOID); Value 0 means that there is no data buffer.
+    ULONG   DataBufferLength;   // length of the buffer
+} FIRMWARE_REQUEST_BLOCK, *PFIRMWARE_REQUEST_BLOCK;
+
+//
+// The request is for Controller if this flag is set. Otherwise, it's for Device/Unit.
+//
+#define FIRMWARE_REQUEST_FLAG_CONTROLLER                    0x00000001
+
+//
+// Indicate that current FW image segment is the last one.
+//
+#define FIRMWARE_REQUEST_FLAG_LAST_SEGMENT                  0x00000002
+
+//
+// Indicate that current FW image segment is the first one.
+//
+#define FIRMWARE_REQUEST_FLAG_FIRST_SEGMENT                 0x00000004
+
+//
+// Indicate that the existing firmware in slot should be activated immediately without
+// controller reset.
+//
+#define FIRMWARE_REQUEST_FLAG_SWITCH_TO_FIRMWARE_WITHOUT_RESET   0x10000000
+
+//
+// Indicate that any existing firmware in slot should be replaced with the downloaded image,
+// and activated with controller reset.
+//
+#define FIRMWARE_REQUEST_FLAG_REPLACE_AND_SWITCH_UPON_RESET      0x20000000
+
+//
+// Indicate that any existing firmware in slot should be replaced with the downloaded image.
+//
+#define FIRMWARE_REQUEST_FLAG_REPLACE_EXISTING_IMAGE             0x40000000
+
+//
+// Indicate that the existing firmware in slot should be activated. 
+// This flag is only valid for fimrware_activate request. It's ignored for other requests.
+//
+#define FIRMWARE_REQUEST_FLAG_SWITCH_TO_EXISTING_FIRMWARE        0x80000000
+
+//
+// Parameter for FIRMWARE_FUNCTION_GET_INFO
+// Input buffer should contain SRB_IO_CONTROL and FIRMWARE_REQUEST_BLOCK data structures.
+// Field "DataBufferOffset" of FIRMWARE_REQUEST_BLOCK points to output data buffer and STORAGE_FIRMWARE_INFO should be returned.
+//
+
+//
+// NOTE: In case of (NTDDI_VERSION >= NTDDI_WINTHRESHOLD), applications should use 
+//          IOCTL_STORAGE_FIRMWARE_GET_INFO
+//          IOCTL_STORAGE_FIRMWARE_DOWNLOAD
+//          IOCTL_STORAGE_FIRMWARE_ACTIVATE
+//      to work on storage firmware query and update.
+//
+//      Storage port driver uses FIRMWARE_FUNCTION_GET_INFO as corresponding interface to communicate to miniport.
+//      Version 1 data structures below are kept for backwards compatibility only. It's recommended that miniport drivers support Version 2 data structures.
+//
+
+//
+// Output parameter for FIRMWARE_FUNCTION_GET_INFO
+// The total size of returned data is for Firmware Info is:
+//   sizeof(STORAGE_FIRMWARE_INFO) + sizeof(STORAGE_FIRMWARE_SLOT_INFO) * SlotCount.
+// If the buffer is not big enough, callee should set "FIRMWARE_STATUS_OUTPUT_BUFFER_TOO_SMALL" into "ReturnCode" field of SRB_IO_CONTROL,
+// and the required size in "DataBufferLength" field of FIRMWARE_REQUEST_BLOCK.
+//
+
+#define STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION         0x1
+#define STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION_V2      0x2
+
+#define STORAGE_FIRMWARE_INFO_INVALID_SLOT              0xFF
+
+typedef struct _STORAGE_FIRMWARE_SLOT_INFO {
+
+    UCHAR   SlotNumber;
+    BOOLEAN ReadOnly;
+    UCHAR   Reserved[6];
+
+    union {
+        UCHAR     Info[8];
+        ULONGLONG AsUlonglong;
+    } Revision;
+
+} STORAGE_FIRMWARE_SLOT_INFO, *PSTORAGE_FIRMWARE_SLOT_INFO;
+
+#define STORAGE_FIRMWARE_SLOT_INFO_V2_REVISION_LENGTH   16
+
+typedef struct _STORAGE_FIRMWARE_SLOT_INFO_V2 {
+
+    UCHAR   SlotNumber;
+    BOOLEAN ReadOnly;
+    UCHAR   Reserved[6];
+
+    UCHAR   Revision[STORAGE_FIRMWARE_SLOT_INFO_V2_REVISION_LENGTH];
+
+} STORAGE_FIRMWARE_SLOT_INFO_V2, *PSTORAGE_FIRMWARE_SLOT_INFO_V2;
+
+
+#pragma warning(push)
+#pragma warning(disable:4200) // nonstandard extension used : zero-sized array in struct/union
+
+typedef struct _STORAGE_FIRMWARE_INFO {
+
+    ULONG   Version;        // STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION
+    ULONG   Size;           // sizeof(STORAGE_FIRMWARE_INFO)
+
+    BOOLEAN UpgradeSupport;
+    UCHAR   SlotCount;
+    UCHAR   ActiveSlot;
+    UCHAR   PendingActivateSlot;
+
+    ULONG   Reserved;
+
+    STORAGE_FIRMWARE_SLOT_INFO Slot[0];
+
+} STORAGE_FIRMWARE_INFO, *PSTORAGE_FIRMWARE_INFO;
+
+typedef struct _STORAGE_FIRMWARE_INFO_V2 {
+
+    ULONG   Version;        // STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION_V2
+    ULONG   Size;           // sizeof(STORAGE_FIRMWARE_INFO_V2)
+
+    BOOLEAN UpgradeSupport;
+    UCHAR   SlotCount;
+    UCHAR   ActiveSlot;
+    UCHAR   PendingActivateSlot;
+
+    BOOLEAN FirmwareShared;         // The firmware applies to both device and adapter. For example: PCIe SSD.
+    UCHAR   Reserved[3];
+
+    ULONG   ImagePayloadAlignment;  // Number of bytes. Max: PAGE_SIZE. The transfer size should be multiple of this unit size. Some protocol requires at least sector size. 0 means the value is not valid.
+    ULONG   ImagePayloadMaxSize;    // for a single command.
+
+    STORAGE_FIRMWARE_SLOT_INFO_V2 Slot[0];
+
+} STORAGE_FIRMWARE_INFO_V2, *PSTORAGE_FIRMWARE_INFO_V2;
+
+
+//
+// Parameter for FIRMWARE_FUNCTION_DOWNLOAD
+// Input buffer should contain SRB_IO_CONTROL and FIRMWARE_REQUEST_BLOCK data structures.
+// Field "DataBufferOffset" of FIRMWARE_REQUEST_BLOCK points to input data buffer that contains STORAGE_FIRMWARE_DOWNLOAD.
+//
+#define STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION         0x1
+#define STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2      0x2
+
+typedef struct _STORAGE_FIRMWARE_DOWNLOAD {
+
+    ULONG       Version;            // STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION
+    ULONG       Size;               // sizeof(STORAGE_FIRMWARE_DOWNLOAD)
+
+    ULONGLONG   Offset;             // image file offset, should be aligned to value of "ImagePayloadAlignment" from STORAGE_FIRMWARE_INFO.
+    ULONGLONG   BufferSize;         // should be multiple of value of "ImagePayloadAlignment" from STORAGE_FIRMWARE_INFO
+
+    UCHAR       ImageBuffer[0];     // firmware image file. 
+
+} STORAGE_FIRMWARE_DOWNLOAD, *PSTORAGE_FIRMWARE_DOWNLOAD; 
+
+typedef struct _STORAGE_FIRMWARE_DOWNLOAD_V2 {
+
+    ULONG       Version;            // STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2
+    ULONG       Size;               // sizeof(STORAGE_FIRMWARE_DOWNLOAD_V2)
+
+    ULONGLONG   Offset;             // image file offset, should be aligned to value of "ImagePayloadAlignment" from STORAGE_FIRMWARE_INFO.
+    ULONGLONG   BufferSize;         // should be multiple of value of "ImagePayloadAlignment" from STORAGE_FIRMWARE_INFO
+
+    UCHAR       Slot;
+    UCHAR       Reserved[3];
+    ULONG       ImageSize;
+
+    UCHAR       ImageBuffer[0];     // firmware image file. 
+
+} STORAGE_FIRMWARE_DOWNLOAD_V2, *PSTORAGE_FIRMWARE_DOWNLOAD_V2; 
+
+#pragma warning(pop)
+
+//
+// Parameter for FIRMWARE_FUNCTION_ACTIVATE
+// Input buffer should contain SRB_IO_CONTROL and FIRMWARE_REQUEST_BLOCK data structures.
+// Field "DataBufferOffset" of FIRMWARE_REQUEST_BLOCK points to input data buffer that contains STORAGE_FIRMWARE_ACTIVATE.
+//
+#define STORAGE_FIRMWARE_ACTIVATE_STRUCTURE_VERSION         0x1
+
+typedef struct _STORAGE_FIRMWARE_ACTIVATE {
+
+    ULONG   Version;
+    ULONG   Size;
+
+    UCHAR   SlotToActivate;
+    UCHAR   Reserved0[3];
+
+} STORAGE_FIRMWARE_ACTIVATE, *PSTORAGE_FIRMWARE_ACTIVATE;
+
+
+
+//
+// SCSI port driver capabilities structure.
+//
+
+typedef struct _IO_SCSI_CAPABILITIES {
+
+    //
+    // Length of this structure
+    //
+
+    ULONG Length;
+
+    //
+    // Maximum transfer size in single SRB
+    //
+
+    ULONG MaximumTransferLength;
+
+    //
+    // Maximum number of physical pages per data buffer
+    //
+
+    ULONG MaximumPhysicalPages;
+
+    //
+    // Async calls from port to class
+    //
+
+    ULONG SupportedAsynchronousEvents;
+
+    //
+    // Alignment mask for data transfers.
+    //
+
+    ULONG AlignmentMask;
+
+    //
+    // Supports tagged queuing
+    //
+
+    BOOLEAN TaggedQueuing;
+
+    //
+    // Host adapter scans down for bios devices.
+    //
+
+    BOOLEAN AdapterScansDown;
+
+    //
+    // The host adapter uses programmed I/O.
+    //
+
+    BOOLEAN AdapterUsesPio;
+
+} IO_SCSI_CAPABILITIES, *PIO_SCSI_CAPABILITIES;
+
+typedef struct _SCSI_ADDRESS {
+    ULONG Length;
+    UCHAR PortNumber;
+    UCHAR PathId;
+    UCHAR TargetId;
+    UCHAR Lun;
+} SCSI_ADDRESS, *PSCSI_ADDRESS;
+
+//
+// Define structure for returning crash dump pointers.
+//
+
+struct _ADAPTER_OBJECT;
+#define DUMP_POINTERS_VERSION_1         1
+#define DUMP_POINTERS_VERSION_2         2
+#define DUMP_POINTERS_VERSION_3         3
+#define DUMP_POINTERS_VERSION_4         4
+#define DUMP_DRIVER_NAME_LENGTH         15
+
+typedef
+LONG
+DUMP_DEVICE_POWERON_ROUTINE(
+    _In_ PVOID Context
+    );
+typedef DUMP_DEVICE_POWERON_ROUTINE *PDUMP_DEVICE_POWERON_ROUTINE;
+
+typedef struct _DUMP_POINTERS_VERSION {
+    //
+    // Dump pointers structure version
+    //
+    ULONG Version;
+
+    //
+    // Dump pointers structure size
+    //
+    ULONG Size;
+
+} DUMP_POINTERS_VERSION, *PDUMP_POINTERS_VERSION;
+
+typedef struct _DUMP_POINTERS {
+    struct _ADAPTER_OBJECT *AdapterObject;
+    PVOID MappedRegisterBase;
+    PVOID DumpData;
+    PVOID CommonBufferVa;
+    LARGE_INTEGER CommonBufferPa;
+    ULONG CommonBufferSize;
+    BOOLEAN AllocateCommonBuffers;
+#if (NTDDI_VERSION < NTDDI_WINXP)
+    UCHAR Spare1[3];
+#else
+    BOOLEAN UseDiskDump;
+    UCHAR Spare1[2];
+#endif
+    PVOID DeviceObject;
+} DUMP_POINTERS, *PDUMP_POINTERS;
+
+typedef struct _DUMP_POINTERS_EX {
+    DUMP_POINTERS_VERSION Header;
+    PVOID DumpData;
+    PVOID CommonBufferVa;
+    ULONG CommonBufferSize;
+    BOOLEAN AllocateCommonBuffers;
+    PVOID DeviceObject;
+    PVOID DriverList;
+
+#if (NTDDI_VERSION >= NTDDI_WIN8)
+
+    //
+    // Start of DUMP_POINTERS_EX_V3 specific fields
+    //
+    ULONG       dwPortFlags;            // Bit mask of various flags, returned by the port driver to crashdump driver
+
+    //
+    // Configuration values for device telemetry collection - obtained from either live device or from the registry.
+    //
+    ULONG       MaxDeviceDumpSectionSize;// Size of the buffer to hold complete telemetry section from the storage stack (header, public and private subsections)
+    ULONG       MaxDeviceDumpLevel;      // Max level of device dump to request from the device at the crash time
+
+    //
+    // Maximum transfer size supported in dump stack
+    //
+    ULONG MaxTransferSize;
+
+    //
+    // Field needed to support DMA operations in diskdump for storport miniports.
+    //
+    PVOID AdapterObject;
+    PVOID MappedRegisterBase;
+
+    //
+    // Pointer to stack managed 'device ready for dump'.
+    //
+
+    PBOOLEAN DeviceReady;
+
+#endif
+
+ 
+#if (NTDDI_VERSION >= NTDDI_WINBLUE)
+    //
+    // Start of DUMP_POINTERS_EX_V4 specific fields
+    //
+
+    //
+    // Dump device power up callback
+    //
+    PDUMP_DEVICE_POWERON_ROUTINE DumpDevicePowerOn;
+    PVOID DumpDevicePowerOnContext;
+
+#endif
+
+} DUMP_POINTERS_EX, *PDUMP_POINTERS_EX;
+
+
+#if (NTDDI_VERSION == NTDDI_WIN8)
+
+//
+// Size of the different DUMP_POINTERS_EX structures
+//
+
+#define DUMP_POINTERS_EX_V2_SIZE    ((ULONG)FIELD_OFFSET(DUMP_POINTERS_EX, dwPortFlags))
+#define DUMP_POINTERS_EX_V3_SIZE    sizeof(DUMP_POINTERS_EX)
+
+#elif (NTDDI_VERSION >= NTDDI_WINBLUE)
+
+#define DUMP_POINTERS_EX_V2_SIZE    ((ULONG)FIELD_OFFSET(DUMP_POINTERS_EX, dwPortFlags))
+#define DUMP_POINTERS_EX_V3_SIZE    ((ULONG)FIELD_OFFSET(DUMP_POINTERS_EX, DumpDevicePowerOn))
+#define DUMP_POINTERS_EX_V4_SIZE    sizeof(DUMP_POINTERS_EX)
+
+#endif
+
+//
+// Bit flag values, returned by the port driver in DUMP_POINTERS_EX structure
+//
+
+//
+// Driver stack & controller support 64-bit physical memory
+//
+#define DUMP_EX_FLAG_SUPPORT_64BITMEMORY        0x00000001
+
+//
+// Driver stack is capable of producing device and driver telemetry data (individual device may not be able to return data)
+//
+#define DUMP_EX_FLAG_SUPPORT_DD_TELEMETRY       0x00000002
+
+//
+// Driver stack is capable of working after a system resume
+//
+#define DUMP_EX_FLAG_RESUME_SUPPORT             0x00000004
+
+//
+// Driver stack is capable to provide driver full path(DUMP_DRIVER_EX is allocated/used by lower stack)
+//
+#define DUMP_EX_FLAG_DRIVER_FULL_PATH_SUPPORT   0x00000008
+
+typedef struct _DUMP_DRIVER {
+
+    //
+    // Dump driver list from port driver
+    //
+    PVOID DumpDriverList;
+
+    //
+    // Name of the driver to be loaded
+    //
+    WCHAR DriverName[DUMP_DRIVER_NAME_LENGTH];
+
+    //
+    // Driver base name
+    //
+    WCHAR BaseName[DUMP_DRIVER_NAME_LENGTH];
+
+} DUMP_DRIVER, *PDUMP_DRIVER;
+
+//
+// Duplicate UNICODE_STRING definition here to eliminate dependancy
+// with other header file.
+//
+// Unicode strings are counted 16-bit character strings. If they are
+// NULL terminated, Length does not include trailing NULL.
+//
+
+typedef struct _NTSCSI_UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+#ifdef MIDL_PASS
+    [size_is(MaximumLength / 2), length_is((Length) / 2) ] USHORT * Buffer;
+#else // MIDL_PASS
+    _Field_size_bytes_part_opt_(MaximumLength, Length) PWCH Buffer;
+#endif // MIDL_PASS
+} NTSCSI_UNICODE_STRING;
+typedef NTSCSI_UNICODE_STRING *PNTSCSI_UNICODE_STRING;
+
+typedef struct _DUMP_DRIVER_EX {
+
+    //
+    // Dump driver list from port driver
+    //
+    PVOID DumpDriverList;
+
+    //
+    // Name of the driver to be loaded
+    //
+    WCHAR DriverName[DUMP_DRIVER_NAME_LENGTH];
+
+    //
+    // Driver base name
+    //
+    WCHAR BaseName[DUMP_DRIVER_NAME_LENGTH];
+
+    //
+    // Driver full path string
+    //
+    NTSCSI_UNICODE_STRING DriverFullPath;
+
+} DUMP_DRIVER_EX, *PDUMP_DRIVER_EX;
+
+
+//
+// Define values for pass-through DataIn field.
+//
+
+#define SCSI_IOCTL_DATA_OUT          0
+#define SCSI_IOCTL_DATA_IN           1
+#define SCSI_IOCTL_DATA_UNSPECIFIED  2
+
+//
+// This value specifies that there is both a data-in and data-out buffer.
+// This value is only relevant when used for the DataDirection field of
+// SCSI_PASS_THROUGH_EX and SCSI_PASS_THROUGH_DIRECT_EX.
+//
+#define SCSI_IOCTL_DATA_BIDIRECTIONAL   3
+
+//
+// Define values for MPIO-pass-through-path Flags field.
+//
+
+#define MPIO_IOCTL_FLAG_USE_PATHID      1
+#define MPIO_IOCTL_FLAG_USE_SCSIADDRESS 2
+#define MPIO_IOCTL_FLAG_INVOLVE_DSM     4
+
+
+#pragma warning(push)
+#pragma warning(disable:4214)   // bit fields other than int to disable this around the struct
+#pragma warning(disable:4201)   // nameless struct/union
+
+//
+// Parameters for IOCTL_SCSI_MINIPORT/IOCTL_MINIPORT_SIGNATURE_ENDURANCE_INFO
+//      The storage port driver uses these structures when communicating with the miniport.
+//
+
+typedef struct _STORAGE_ENDURANCE_INFO {
+    ULONG       ValidFields;        // ValidFields represents bit mapping of valid fields of any type
+                                    // Eg: Bit 0 stands for GroupId, Bit 1 stands for Flags, Bit 3 for BytesReadCount
+
+    ULONG       GroupId;            // Set Id Eg: Set Id for NVMe sets
+
+    struct {
+        ULONG   Shared:1;           // TRUE if information is shared with multiple units/groups
+
+        ULONG   Reserved:31;
+    } Flags;
+
+    ULONG       LifePercentage;         // Used life percentage
+
+    UCHAR       BytesReadCount[16];     // Total bytes read from device (Billion Unit)
+
+    UCHAR       ByteWriteCount[16];     // Total bytes written to device (Billion Unit)
+
+} STORAGE_ENDURANCE_INFO, *PSTORAGE_ENDURANCE_INFO;
+
+typedef struct _STORAGE_ENDURANCE_DATA_DESCRIPTOR {
+    ULONG                      Version;            // Version of the endurance information structure
+
+    ULONG                      Size;               // Size of the endurance information
+
+    STORAGE_ENDURANCE_INFO     EnduranceInfo;      // Endurance Information of the device
+
+} STORAGE_ENDURANCE_DATA_DESCRIPTOR, *PSTORAGE_ENDURANCE_DATA_DESCRIPTOR;
+
+#pragma warning(pop)
+
+#if _MSC_VER >= 1200
+#pragma warning(pop)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM) */
+#pragma endregion
+
+#endif
+

--- a/src/MaksIT.LTO.Backup/Application.cs
+++ b/src/MaksIT.LTO.Backup/Application.cs
@@ -15,585 +15,702 @@ using MaksIT.LTO.Core.Helpers;
 
 namespace MaksIT.LTO.Backup;
 
-public class Application {
+public class Application
+{
 
-  private const string _descriptoFileName = "descriptor.json";
-  private const string _secretFileName = "secret.txt";
+    private const string _descriptoFileName = "descriptor.json";
+    private const string _secretFileName = "secret.txt";
 
-  private readonly string appPath = AppDomain.CurrentDomain.BaseDirectory;
-  private readonly string _tapePath;
-  private readonly string _descriptorFilePath;
-  private readonly string _secretFilePath;
+    private readonly string appPath = AppDomain.CurrentDomain.BaseDirectory;
+    private readonly string _tapePath;
+    private readonly string _descriptorFilePath;
+    private readonly string _secretFilePath;
 
-  private readonly ILogger<Application> _logger;
-  private readonly ILogger<TapeDeviceHandler> _tapeDeviceLogger;
-  private readonly ILogger<NetworkConnection> _networkConnectionLogger;
+    private readonly ILogger<Application> _logger;
+    private readonly ILogger<TapeDeviceHandler> _tapeDeviceLogger;
+    private readonly ILogger<NetworkConnection> _networkConnectionLogger;
 
-  private readonly Configuration _configuration;
-  private readonly string _secret;
+    private readonly Configuration _configuration;
+    private readonly string _secret;
 
-  public Application(
-    ILogger<Application> logger,
-    ILoggerFactory loggerFactory,
-    IOptions<Configuration> configuration
-  ) {
-    _logger = logger;
-    _tapeDeviceLogger = loggerFactory.CreateLogger<TapeDeviceHandler>();
-    _networkConnectionLogger = loggerFactory.CreateLogger<NetworkConnection>();
+    public Application(
+      ILogger<Application> logger,
+      ILoggerFactory loggerFactory,
+      IOptions<Configuration> configuration
+    )
+    {
+        _logger = logger;
+        _tapeDeviceLogger = loggerFactory.CreateLogger<TapeDeviceHandler>();
+        _networkConnectionLogger = loggerFactory.CreateLogger<NetworkConnection>();
 
-    _descriptorFilePath = Path.Combine(appPath, _descriptoFileName);
-    _secretFilePath = Path.Combine(appPath, _secretFileName);
+        _descriptorFilePath = Path.Combine(appPath, _descriptoFileName);
+        _secretFilePath = Path.Combine(appPath, _secretFileName);
 
-    _configuration = configuration.Value;
-    _tapePath = _configuration.TapePath;
+        _configuration = configuration.Value;
+        _tapePath = _configuration.TapePath;
 
-    var secret = Environment.GetEnvironmentVariable("LTO_BACKUP_SECRET")
-      ?? Environment.GetEnvironmentVariable("LTO_BACKUP_SECRET", EnvironmentVariableTarget.Machine);
+        var secret = Environment.GetEnvironmentVariable("LTO_BACKUP_SECRET")
+          ?? Environment.GetEnvironmentVariable("LTO_BACKUP_SECRET", EnvironmentVariableTarget.Machine);
 
-    if (!string.IsNullOrWhiteSpace(secret))
-      _secret = secret;
-    else if (!File.Exists(_secretFilePath)) {
-      _secret = AESGCMUtility.GenerateKeyBase64();
-      File.WriteAllText(_secretFilePath, _secret);
-    }
-    else
-      _secret = File.ReadAllText(_secretFilePath);
-
-    if (string.IsNullOrWhiteSpace(_secret)) {
-      throw new InvalidOperationException("Secret is required for encryption.");
-    }
-  }
-
-  public void Run() {
-    Console.OutputEncoding = Encoding.UTF8;
-
-    while (true) {
-      Console.WriteLine("MaksIT.LTO.Backup v0.0.1");
-      Console.WriteLine("© Maksym Sadovnychyy (MAKS-IT) 2024");
-
-      Console.WriteLine("\nSelect an action:");
-      Console.WriteLine("1. Load tape");
-      Console.WriteLine("2. Backup");
-      Console.WriteLine("3. Restore");
-      Console.WriteLine("4. Eject tape");
-      Console.WriteLine("5. Get device status");
-      Console.WriteLine("6. Tape Erase (Short)");
-      Console.WriteLine("7. Exit");
-      Console.Write("Enter your choice: ");
-
-      var choice = Console.ReadLine();
-
-      try {
-        switch (choice) {
-          case "1":
-            LoadTape();
-            break;
-          case "2":
-            Backup();
-            break;
-          case "3":
-            Restore();
-            break;
-          case "4":
-            EjectTape();
-            break;
-          case "5":
-            GetDeviceStatus();
-            break;
-          case "6":
-            TapeErase();
-            break;
-          case "7":
-            Console.WriteLine("Exiting...");
-            return;
-          default:
-            Console.WriteLine("Invalid choice. Please try again.");
-            break;
+        if (!string.IsNullOrWhiteSpace(secret))
+            _secret = secret;
+        else if (!File.Exists(_secretFilePath))
+        {
+            _secret = AESGCMUtility.GenerateKeyBase64();
+            File.WriteAllText(_secretFilePath, _secret);
         }
-      }
-      catch (Exception ex) {
-        _logger.LogError(ex, $"An error occurred: {ex.Message}");
-      }
-    }
-  }
+        else
+            _secret = File.ReadAllText(_secretFilePath);
 
-  private void LoadTape() {
-    using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
-    LoadTape(handler);
-  }
-
-  private void LoadTape(TapeDeviceHandler handler) {
-    handler.Prepare(TapeDeviceHandler.TAPE_LOAD);
-    Thread.Sleep(2000);
-
-    _logger.LogInformation("Tape loaded.");
-  }
-
-  private void EjectTape() {
-    using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
-    EjectTape(handler);
-  }
-
-  private void EjectTape(TapeDeviceHandler handler) {
-    handler.Prepare(TapeDeviceHandler.TAPE_UNLOAD);
-    Thread.Sleep(2000);
-
-    _logger.LogInformation("Tape ejected.");
-  }
-
-  private void TapeErase() {
-    using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
-    LoadTape(handler);
-
-    handler.SetMediaParams(LTOBlockSizes.LTO5);
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-    Thread.Sleep(2000);
-
-    handler.Prepare(TapeDeviceHandler.TAPE_TENSION);
-    Thread.Sleep(2000);
-
-    handler.Prepare(TapeDeviceHandler.TAPE_LOCK);
-    Thread.Sleep(2000);
-
-    handler.Erase(TapeDeviceHandler.TAPE_ERASE_SHORT);
-    Thread.Sleep(2000);
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-    Thread.Sleep(2000);
-
-    _logger.LogInformation("Tape erased.");
-  }
-
-  private void GetDeviceStatus() {
-    using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
-    handler.GetStatus();
-  }
-
-  private void PathAccessWrapper(WorkingFolder workingFolder, Action<string> myAction) {
-
-    if (workingFolder.LocalPath != null) {
-      var localPath = workingFolder.LocalPath.Path;
-      var path = workingFolder.LocalPath.Path;
-
-      myAction(path);
-    }
-    else if (workingFolder.RemotePath != null) {
-      var remotePath = workingFolder.RemotePath;
-
-      if (remotePath.Protocol == "SMB") {
-        NetworkCredential? networkCredential = default;
-
-        if (remotePath.PasswordCredentials != null) {
-          var username = remotePath.PasswordCredentials.Username;
-          var password = remotePath.PasswordCredentials.Password;
-
-          networkCredential = new NetworkCredential(username, password);
+        if (string.IsNullOrWhiteSpace(_secret))
+        {
+            throw new InvalidOperationException("Secret is required for encryption.");
         }
+    }
 
-        var smbPath = remotePath.Path;
+    public void Run()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
 
-        if (networkCredential == null) {
-          throw new InvalidOperationException("Network credentials are required for remote paths.");
+        while (true)
+        {
+            Console.WriteLine("MaksIT.LTO.Backup v0.0.3");
+            Console.WriteLine("© Maksym Sadovnychyy (MAKS-IT) 2024");
+
+            Console.WriteLine("\nSelect an action:");
+            Console.WriteLine("1. Load tape");
+            Console.WriteLine("2. Backup");
+            Console.WriteLine("3. Restore");
+            Console.WriteLine("4. Eject tape");
+            Console.WriteLine("5. Get device status");
+            Console.WriteLine("6. Tape Erase (Short)");
+            Console.WriteLine("7. Read Cartridge Memory");
+            Console.WriteLine("8. Write Cartridge Memory");
+            Console.WriteLine("9. Exit");
+            Console.Write("Enter your choice: ");
+
+            var choice = Console.ReadLine();
+
+            try
+            {
+                switch (choice)
+                {
+                    case "1":
+                        LoadTape();
+                        break;
+                    case "2":
+                        Backup();
+                        break;
+                    case "3":
+                        Restore();
+                        break;
+                    case "4":
+                        EjectTape();
+                        break;
+                    case "5":
+                        GetDeviceStatus();
+                        break;
+                    case "6":
+                        TapeErase();
+                        break;
+                    case "7":
+                        ReadCartrigeMemory();
+                        break;
+                    case "8":
+                        WriteCartrigeMemory();
+                        break;
+                    case "9":
+                        Console.WriteLine("Exiting...");
+                        return;
+                    default:
+                        Console.WriteLine("Invalid choice. Please try again.");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"An error occurred: {ex.Message}");
+            }
         }
-          
-        using (new NetworkConnection(_networkConnectionLogger, smbPath, networkCredential)) {
-           myAction(smbPath);
-        }
-      }
-    }
-  }
-
-  private void CreateDescriptor(WorkingFolder workingFolder, string descriptorFilePath, uint blockSize) {
-
-    PathAccessWrapper(workingFolder, (directoryPath) => {
-      var files = Directory.GetFiles(directoryPath, "*.*", SearchOption.AllDirectories);
-
-      // Define list to hold file descriptors
-      var descriptor = new List<FileDescriptor>();
-      uint currentTapeBlock = 0;
-
-      foreach (var filePath in files) {
-        var fileInfo = new FileInfo(filePath);
-        var relativePath = Path.GetRelativePath(directoryPath, filePath);
-        var numberOfBlocks = (uint)((fileInfo.Length + blockSize - 1) / blockSize);
-
-        // Calculate CRC32 checksum for file integrity
-        string fileHash = ChecksumUtility.CalculateCRC32ChecksumFromFileInChunks(filePath, (int)blockSize);
-
-        descriptor.Add(new FileDescriptor {
-          StartBlock = currentTapeBlock, // Position of the file on the tape
-          NumberOfBlocks = numberOfBlocks, // Number of blocks used by the file
-          FilePath = relativePath,
-          FileSize = fileInfo.Length,
-          CreationTime = fileInfo.CreationTime,
-          LastModifiedTime = fileInfo.LastWriteTime,
-          FileHash = fileHash
-        });
-
-        currentTapeBlock += numberOfBlocks;
-      }
-
-      // Convert descriptor list to JSON and include BlockSize
-      string descriptorJson = JsonSerializer.Serialize(new BackupDescriptor {
-        BlockSize = blockSize,
-        Files = descriptor
-      });
-
-      File.WriteAllText(descriptorFilePath, descriptorJson);
-    });
-  }
-
-
-
-  private void WriteFilesToTape(WorkingFolder workingFolder, string descriptorFilePath, uint blockSize) {
-    PathAccessWrapper(workingFolder, (directoryPath) => {
-      _logger.LogInformation($"Writing files to tape from: {directoryPath}.");
-      _logger.LogInformation($"Block Size: {blockSize}.");
-
-      using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
-
-      LoadTape(handler);
-
-      handler.SetMediaParams(blockSize);
-
-      handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-      Thread.Sleep(2000);
-
-      handler.Prepare(TapeDeviceHandler.TAPE_TENSION);
-      Thread.Sleep(2000);
-
-      handler.Prepare(TapeDeviceHandler.TAPE_LOCK);
-      Thread.Sleep(2000);
-
-      handler.WaitForTapeReady();
-
-      // Read descriptor from file system
-      string descriptorJson = File.ReadAllText(descriptorFilePath);
-      var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(descriptorJson);
-
-      if (descriptor == null) {
-        throw new InvalidOperationException("Failed to deserialize descriptor.");
-      }
-
-      var currentTapeBlock = (descriptorJson.Length + blockSize - 1) / blockSize;
-
-      foreach (var file in descriptor.Files) {
-        var filePath = Path.Combine(directoryPath, file.FilePath);
-        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        using var bufferedStream = new BufferedStream(fileStream, (int)blockSize);
-
-        byte[] buffer = new byte[blockSize];
-        int bytesRead;
-        for (var i = 0; i < file.NumberOfBlocks; i++) {
-          bytesRead = bufferedStream.Read(buffer, 0, buffer.Length);
-          if (bytesRead < buffer.Length) {
-            // Zero-fill the remaining part of the buffer if the last block is smaller than blockSize
-            Array.Clear(buffer, bytesRead, buffer.Length - bytesRead);
-          }
-          
-          var writeError = handler.WriteData(buffer);
-          if (writeError != 0) {
-            _logger.LogInformation($"Failed to write file: {filePath}");
-            return;
-          }
-
-          currentTapeBlock++;
-          Thread.Sleep(_configuration.WriteDelay); // Small delay between blocks
-        }
-      }
-
-      // write mark to indicate end of files
-      handler.WriteMarks(TapeDeviceHandler.TAPE_FILEMARKS, 1);
-      Thread.Sleep(_configuration.WriteDelay);
-
-      // write descriptor to tape
-      var descriptorData = Encoding.UTF8.GetBytes(descriptorJson);
-
-      // encrypt the serialized descriptor
-      var encryptedDescriptorData = AESGCMUtility.EncryptData(descriptorData, _secret);
-
-      // add padding to the encrypted descriptor data
-      var paddedDescriptorData = PaddingUtility.AddPadding(encryptedDescriptorData, (int)blockSize);
-
-      // calculate the number of blocks needed
-      var descriptorBlocks = (paddedDescriptorData.Length + blockSize - 1) / blockSize;
-      for (var i = 0; i < descriptorBlocks; i++) {
-        var startIndex = i * blockSize;
-        var length = Math.Min(blockSize, paddedDescriptorData.Length - startIndex);
-        var block = new byte[blockSize]; // Initialized with zeros by default
-        Array.Copy(paddedDescriptorData, startIndex, block, 0, length);
-
-        var writeError = handler.WriteData(block);
-        if (writeError != 0)
-          return;
-
-        currentTapeBlock++;
-        Thread.Sleep(_configuration.WriteDelay); // Small delay between blocks
-      }
-
-      // write mark to indicate end of files
-      handler.WriteMarks(TapeDeviceHandler.TAPE_FILEMARKS, 2);
-      Thread.Sleep(_configuration.WriteDelay);
-
-      handler.Prepare(TapeDeviceHandler.TAPE_UNLOCK);
-      Thread.Sleep(2000);
-
-      handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-      Thread.Sleep(2000);
-
-    });
-  }
-
-  private BackupDescriptor? FindDescriptor(uint blockSize) {
-    _logger.LogInformation("Searching for descriptor on tape...");
-    _logger.LogInformation($"Block Size: {blockSize}.");
-
-    using var handler = new TapeDeviceHandler(_tapeDeviceLogger,_tapePath);
-
-    LoadTape(handler);
-
-    handler.SetMediaParams(blockSize);
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-    Thread.Sleep(2000);
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_SPACE_FILEMARKS, 0, 1);
-    Thread.Sleep(2000);
-
-    var endOfBackupMarkerPosition = handler.GetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK);
-    if (endOfBackupMarkerPosition.Error != null || endOfBackupMarkerPosition.OffsetLow == null)
-      return null;
-
-    _logger.LogInformation($"End of backup marker position: {endOfBackupMarkerPosition.OffsetLow}");
-
-    var descriptorBlocks = endOfBackupMarkerPosition.OffsetLow;
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_SPACE_FILEMARKS, 0, 2);
-    Thread.Sleep(2000);
-
-    var endOfDescriptorMarkerPosition = handler.GetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK);
-    if (endOfDescriptorMarkerPosition.Error != null || endOfDescriptorMarkerPosition.OffsetLow == null)
-      return null;
-
-    _logger.LogInformation($"End of descriptor marker position: {endOfDescriptorMarkerPosition.OffsetLow}");
-
-    descriptorBlocks = endOfDescriptorMarkerPosition.OffsetLow - descriptorBlocks;
-
-    if (descriptorBlocks == null)
-      return null;
-
-    _logger.LogInformation($"Descriptor blocks to read: {descriptorBlocks}");
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK, 0, (long)(endOfDescriptorMarkerPosition.OffsetLow - descriptorBlocks));
-    Thread.Sleep(2000);
-
-    descriptorBlocks -= 2;
-
-    var paddedData = new byte[(descriptorBlocks.Value) * blockSize];
-    var buffer = new byte[blockSize];
-
-    for (var i = 0; i < descriptorBlocks; i++) {
-      var bytesRead = handler.ReadData(buffer, 0, buffer.Length);
-
-      // Copy the read data into the encryptedData array
-      Array.Copy(buffer, 0, paddedData, i * blockSize, buffer.Length);
     }
 
-    // i need to remove padding from the data
-    var encryptedData = PaddingUtility.RemovePadding(paddedData, (int)blockSize);
-
-    // decrypt the data
-    var decryptedData = AESGCMUtility.DecryptData(encryptedData, _secret);
-
-    // Convert byte array to string and trim ending zeros
-    var json = Encoding.UTF8.GetString(decryptedData);
-
-    try {
-      var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(json);
-      if (descriptor != null) {
-        _logger.LogInformation("Descriptor read successfully.");
-        return descriptor;
-      }
-    }
-    catch (JsonException ex) {
-      _logger.LogInformation($"Failed to parse descriptor JSON: {ex.Message}");
-      return null;
+    private void LoadTape()
+    {
+        using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+        LoadTape(handler);
     }
 
-    handler.Prepare(TapeDeviceHandler.TAPE_UNLOCK);
-    Thread.Sleep(2000);
-
-    handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-    Thread.Sleep(2000);
-
-    return null;
-  }
-
-  private void RestoreDirectory(BackupDescriptor descriptor, WorkingFolder workingFolder) {
-
-    PathAccessWrapper(workingFolder, (restoreDirectoryPath) => {
-      _logger.LogInformation("Restoring files to directory: " + restoreDirectoryPath);
-      _logger.LogInformation("Block Size: " + descriptor.BlockSize);
-
-      using var handler = new TapeDeviceHandler(_tapeDeviceLogger,_tapePath);
-
-      LoadTape(handler);
-
-      handler.SetMediaParams(descriptor.BlockSize);
-
-      handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-      Thread.Sleep(2000);
-
-      foreach (var file in descriptor.Files) {
-        // Set position to the start block of the file
-        handler.SetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK, 0, file.StartBlock);
+    private void LoadTape(TapeDeviceHandler handler)
+    {
+        handler.Prepare(TapeDeviceHandler.TAPE_LOAD);
         Thread.Sleep(2000);
 
-        var filePath = Path.Combine(restoreDirectoryPath, file.FilePath);
-        var directoryPath = Path.GetDirectoryName(filePath);
-        if (directoryPath != null) {
-          Directory.CreateDirectory(directoryPath);
+        _logger.LogInformation("Tape loaded.");
+    }
+
+    private void EjectTape()
+    {
+        using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+        EjectTape(handler);
+    }
+
+    private void EjectTape(TapeDeviceHandler handler)
+    {
+        handler.Prepare(TapeDeviceHandler.TAPE_UNLOAD);
+        Thread.Sleep(2000);
+
+        _logger.LogInformation("Tape ejected.");
+    }
+
+    private void TapeErase()
+    {
+        using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+        LoadTape(handler);
+
+        handler.SetMediaParams(LTOBlockSizes.LTO5);
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+        Thread.Sleep(2000);
+
+        handler.Prepare(TapeDeviceHandler.TAPE_TENSION);
+        Thread.Sleep(2000);
+
+        handler.Prepare(TapeDeviceHandler.TAPE_LOCK);
+        Thread.Sleep(2000);
+
+        handler.Erase(TapeDeviceHandler.TAPE_ERASE_SHORT);
+        Thread.Sleep(2000);
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+        Thread.Sleep(2000);
+
+        _logger.LogInformation("Tape erased.");
+    }
+
+    private void GetDeviceStatus()
+    {
+        using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+        handler.GetStatus();
+    }
+
+    private void PathAccessWrapper(WorkingFolder workingFolder, Action<string> myAction)
+    {
+
+        if (workingFolder.LocalPath != null)
+        {
+            var localPath = workingFolder.LocalPath.Path;
+            var path = workingFolder.LocalPath.Path;
+
+            myAction(path);
         }
+        else if (workingFolder.RemotePath != null)
+        {
+            var remotePath = workingFolder.RemotePath;
 
-        using (var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write)) {
-          var buffer = new byte[descriptor.BlockSize];
+            if (remotePath.Protocol == "SMB")
+            {
+                NetworkCredential? networkCredential = default;
 
-          for (var i = 0; i < file.NumberOfBlocks; i++) {
-            var bytesRead = handler.ReadData(buffer, 0, buffer.Length);
-            if (bytesRead < buffer.Length) {
-              // Zero-fill the remaining part of the buffer if the last block is smaller than blockSize
-              Array.Clear(buffer, bytesRead, buffer.Length - bytesRead);
+                if (remotePath.PasswordCredentials != null)
+                {
+                    var username = remotePath.PasswordCredentials.Username;
+                    var password = remotePath.PasswordCredentials.Password;
+
+                    networkCredential = new NetworkCredential(username, password);
+                }
+
+                var smbPath = remotePath.Path;
+
+                if (networkCredential == null)
+                {
+                    throw new InvalidOperationException("Network credentials are required for remote paths.");
+                }
+
+                using (new NetworkConnection(_networkConnectionLogger, smbPath, networkCredential))
+                {
+                    myAction(smbPath);
+                }
+            }
+        }
+    }
+
+    private void CreateDescriptor(WorkingFolder workingFolder, string descriptorFilePath, uint blockSize)
+    {
+
+        PathAccessWrapper(workingFolder, (directoryPath) =>
+        {
+            var files = Directory.GetFiles(directoryPath, "*.*", SearchOption.AllDirectories);
+
+            // Define list to hold file descriptors
+            var descriptor = new List<FileDescriptor>();
+            uint currentTapeBlock = 0;
+
+            foreach (var filePath in files)
+            {
+                var fileInfo = new FileInfo(filePath);
+                var relativePath = Path.GetRelativePath(directoryPath, filePath);
+                var numberOfBlocks = (uint)((fileInfo.Length + blockSize - 1) / blockSize);
+
+                // Calculate CRC32 checksum for file integrity
+                string fileHash = ChecksumUtility.CalculateCRC32ChecksumFromFileInChunks(filePath, (int)blockSize);
+
+                descriptor.Add(new FileDescriptor
+                {
+                    StartBlock = currentTapeBlock, // Position of the file on the tape
+                    NumberOfBlocks = numberOfBlocks, // Number of blocks used by the file
+                    FilePath = relativePath,
+                    FileSize = fileInfo.Length,
+                    CreationTime = fileInfo.CreationTime,
+                    LastModifiedTime = fileInfo.LastWriteTime,
+                    FileHash = fileHash
+                });
+
+                currentTapeBlock += numberOfBlocks;
             }
 
-            var bytesToWrite = (i == file.NumberOfBlocks - 1) ? (int)(file.FileSize % descriptor.BlockSize) : buffer.Length;
-            fileStream.Write(buffer, 0, bytesToWrite);
-          }
+            // Convert descriptor list to JSON and include BlockSize
+            string descriptorJson = JsonSerializer.Serialize(new BackupDescriptor
+            {
+                BlockSize = blockSize,
+                Files = descriptor
+            });
+
+            File.WriteAllText(descriptorFilePath, descriptorJson);
+        });
+    }
+
+
+
+    private void WriteFilesToTape(WorkingFolder workingFolder, string descriptorFilePath, uint blockSize)
+    {
+        PathAccessWrapper(workingFolder, (directoryPath) =>
+        {
+            _logger.LogInformation($"Writing files to tape from: {directoryPath}.");
+            _logger.LogInformation($"Block Size: {blockSize}.");
+
+            using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+
+            LoadTape(handler);
+
+            handler.SetMediaParams(blockSize);
+
+            handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+            Thread.Sleep(2000);
+
+            handler.Prepare(TapeDeviceHandler.TAPE_TENSION);
+            Thread.Sleep(2000);
+
+            handler.Prepare(TapeDeviceHandler.TAPE_LOCK);
+            Thread.Sleep(2000);
+
+            handler.WaitForTapeReady();
+
+            // Read descriptor from file system
+            string descriptorJson = File.ReadAllText(descriptorFilePath);
+            var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(descriptorJson);
+
+            if (descriptor == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize descriptor.");
+            }
+
+            var currentTapeBlock = (descriptorJson.Length + blockSize - 1) / blockSize;
+
+            foreach (var file in descriptor.Files)
+            {
+                var filePath = Path.Combine(directoryPath, file.FilePath);
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+                using var bufferedStream = new BufferedStream(fileStream, (int)blockSize);
+
+                byte[] buffer = new byte[blockSize];
+                int bytesRead;
+                for (var i = 0; i < file.NumberOfBlocks; i++)
+                {
+                    bytesRead = bufferedStream.Read(buffer, 0, buffer.Length);
+                    if (bytesRead < buffer.Length)
+                    {
+                        // Zero-fill the remaining part of the buffer if the last block is smaller than blockSize
+                        Array.Clear(buffer, bytesRead, buffer.Length - bytesRead);
+                    }
+
+                    var writeError = handler.WriteData(buffer);
+                    if (writeError != 0)
+                    {
+                        _logger.LogInformation($"Failed to write file: {filePath}");
+                        return;
+                    }
+
+                    currentTapeBlock++;
+                    Thread.Sleep(_configuration.WriteDelay); // Small delay between blocks
+                }
+            }
+
+            // write mark to indicate end of files
+            handler.WriteMarks(TapeDeviceHandler.TAPE_FILEMARKS, 1);
+            Thread.Sleep(_configuration.WriteDelay);
+
+            // write descriptor to tape
+            var descriptorData = Encoding.UTF8.GetBytes(descriptorJson);
+
+            // encrypt the serialized descriptor
+            var encryptedDescriptorData = AESGCMUtility.EncryptData(descriptorData, _secret);
+
+            // add padding to the encrypted descriptor data
+            var paddedDescriptorData = PaddingUtility.AddPadding(encryptedDescriptorData, (int)blockSize);
+
+            // calculate the number of blocks needed
+            var descriptorBlocks = (paddedDescriptorData.Length + blockSize - 1) / blockSize;
+            for (var i = 0; i < descriptorBlocks; i++)
+            {
+                var startIndex = i * blockSize;
+                var length = Math.Min(blockSize, paddedDescriptorData.Length - startIndex);
+                var block = new byte[blockSize]; // Initialized with zeros by default
+                Array.Copy(paddedDescriptorData, startIndex, block, 0, length);
+
+                var writeError = handler.WriteData(block);
+                if (writeError != 0)
+                    return;
+
+                currentTapeBlock++;
+                Thread.Sleep(_configuration.WriteDelay); // Small delay between blocks
+            }
+
+            // write mark to indicate end of files
+            handler.WriteMarks(TapeDeviceHandler.TAPE_FILEMARKS, 2);
+            Thread.Sleep(_configuration.WriteDelay);
+
+            handler.Prepare(TapeDeviceHandler.TAPE_UNLOCK);
+            Thread.Sleep(2000);
+
+            handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+            Thread.Sleep(2000);
+
+        });
+    }
+
+    private BackupDescriptor? FindDescriptor(uint blockSize)
+    {
+        _logger.LogInformation("Searching for descriptor on tape...");
+        _logger.LogInformation($"Block Size: {blockSize}.");
+
+        using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+
+        LoadTape(handler);
+
+        handler.SetMediaParams(blockSize);
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+        Thread.Sleep(2000);
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_SPACE_FILEMARKS, 0, 1);
+        Thread.Sleep(2000);
+
+        var endOfBackupMarkerPosition = handler.GetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK);
+        if (endOfBackupMarkerPosition.Error != null || endOfBackupMarkerPosition.OffsetLow == null)
+            return null;
+
+        _logger.LogInformation($"End of backup marker position: {endOfBackupMarkerPosition.OffsetLow}");
+
+        var descriptorBlocks = endOfBackupMarkerPosition.OffsetLow;
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_SPACE_FILEMARKS, 0, 2);
+        Thread.Sleep(2000);
+
+        var endOfDescriptorMarkerPosition = handler.GetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK);
+        if (endOfDescriptorMarkerPosition.Error != null || endOfDescriptorMarkerPosition.OffsetLow == null)
+            return null;
+
+        _logger.LogInformation($"End of descriptor marker position: {endOfDescriptorMarkerPosition.OffsetLow}");
+
+        descriptorBlocks = endOfDescriptorMarkerPosition.OffsetLow - descriptorBlocks;
+
+        if (descriptorBlocks == null)
+            return null;
+
+        _logger.LogInformation($"Descriptor blocks to read: {descriptorBlocks}");
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK, 0, (long)(endOfDescriptorMarkerPosition.OffsetLow - descriptorBlocks));
+        Thread.Sleep(2000);
+
+        descriptorBlocks -= 2;
+
+        var paddedData = new byte[(descriptorBlocks.Value) * blockSize];
+        var buffer = new byte[blockSize];
+
+        for (var i = 0; i < descriptorBlocks; i++)
+        {
+            var bytesRead = handler.ReadData(buffer, 0, buffer.Length);
+
+            // Copy the read data into the encryptedData array
+            Array.Copy(buffer, 0, paddedData, i * blockSize, buffer.Length);
         }
 
-        // check checksum of restored file with the one in descriptor
-        if (ChecksumUtility.VerifyCRC32ChecksumFromFileInChunks(filePath, file.FileHash, (int)descriptor.BlockSize))
-          _logger.LogInformation($"Restored file: {filePath}");
+        // i need to remove padding from the data
+        var encryptedData = PaddingUtility.RemovePadding(paddedData, (int)blockSize);
+
+        // decrypt the data
+        var decryptedData = AESGCMUtility.DecryptData(encryptedData, _secret);
+
+        // Convert byte array to string and trim ending zeros
+        var json = Encoding.UTF8.GetString(decryptedData);
+
+        try
+        {
+            var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(json);
+            if (descriptor != null)
+            {
+                _logger.LogInformation("Descriptor read successfully.");
+                return descriptor;
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogInformation($"Failed to parse descriptor JSON: {ex.Message}");
+            return null;
+        }
+
+        handler.Prepare(TapeDeviceHandler.TAPE_UNLOCK);
+        Thread.Sleep(2000);
+
+        handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+        Thread.Sleep(2000);
+
+        return null;
+    }
+
+    private void RestoreDirectory(BackupDescriptor descriptor, WorkingFolder workingFolder)
+    {
+
+        PathAccessWrapper(workingFolder, (restoreDirectoryPath) =>
+        {
+            _logger.LogInformation("Restoring files to directory: " + restoreDirectoryPath);
+            _logger.LogInformation("Block Size: " + descriptor.BlockSize);
+
+            using var handler = new TapeDeviceHandler(_tapeDeviceLogger, _tapePath);
+
+            LoadTape(handler);
+
+            handler.SetMediaParams(descriptor.BlockSize);
+
+            handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+            Thread.Sleep(2000);
+
+            foreach (var file in descriptor.Files)
+            {
+                // Set position to the start block of the file
+                handler.SetPosition(TapeDeviceHandler.TAPE_ABSOLUTE_BLOCK, 0, file.StartBlock);
+                Thread.Sleep(2000);
+
+                var filePath = Path.Combine(restoreDirectoryPath, file.FilePath);
+                var directoryPath = Path.GetDirectoryName(filePath);
+                if (directoryPath != null)
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
+
+                using (var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
+                {
+                    var buffer = new byte[descriptor.BlockSize];
+
+                    for (var i = 0; i < file.NumberOfBlocks; i++)
+                    {
+                        var bytesRead = handler.ReadData(buffer, 0, buffer.Length);
+                        if (bytesRead < buffer.Length)
+                        {
+                            // Zero-fill the remaining part of the buffer if the last block is smaller than blockSize
+                            Array.Clear(buffer, bytesRead, buffer.Length - bytesRead);
+                        }
+
+                        var bytesToWrite = (i == file.NumberOfBlocks - 1) ? (int)(file.FileSize % descriptor.BlockSize) : buffer.Length;
+                        fileStream.Write(buffer, 0, bytesToWrite);
+                    }
+                }
+
+                // check checksum of restored file with the one in descriptor
+                if (ChecksumUtility.VerifyCRC32ChecksumFromFileInChunks(filePath, file.FileHash, (int)descriptor.BlockSize))
+                    _logger.LogInformation($"Restored file: {filePath}");
+                else
+                    _logger.LogInformation($"Checksum mismatch for file: {filePath}");
+            }
+
+            handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
+            Thread.Sleep(2000);
+        });
+    }
+
+    private int CheckMediaSize(string ltoGen)
+    {
+        var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(File.ReadAllText(_descriptorFilePath));
+        if (descriptor == null)
+        {
+            _logger.LogInformation("Failed to read descriptor.");
+            return 1;
+        }
+
+        var encryptedDescriptorData = AESGCMUtility.EncryptData(File.ReadAllBytes(_descriptorFilePath), _secret);
+
+        var paddedDescriptorData = PaddingUtility.AddPadding(encryptedDescriptorData, (int)descriptor.BlockSize);
+
+        const ulong fileMarkBlocks = 2;
+
+        var descriptorSize = paddedDescriptorData.Length;
+        var descriptorSizeBlocks = Math.Ceiling((double)descriptorSize / descriptor.BlockSize);
+
+        var totalBlocks = fileMarkBlocks + descriptorSizeBlocks;
+
+        var maxBlocks = LTOBlockSizes.GetMaxBlocks(ltoGen);
+        if (totalBlocks > maxBlocks)
+        {
+            _logger.LogInformation("Backup will not fit on tape. Please use a larger tape.");
+            return 1;
+        }
         else
-          _logger.LogInformation($"Checksum mismatch for file: {filePath}");
-      }
+        {
+            _logger.LogInformation("Backup will fit on tape.");
+        }
 
-      handler.SetPosition(TapeDeviceHandler.TAPE_REWIND);
-      Thread.Sleep(2000);
-    });
-  }
-
-  private int CheckMediaSize(string ltoGen) {
-    var descriptor = JsonSerializer.Deserialize<BackupDescriptor>(File.ReadAllText(_descriptorFilePath));
-    if (descriptor == null) {
-      _logger.LogInformation("Failed to read descriptor.");
-      return 1;
+        return 0;
     }
 
-    var encryptedDescriptorData = AESGCMUtility.EncryptData(File.ReadAllBytes(_descriptorFilePath), _secret);
+    private void Backup()
+    {
+        while (true)
+        {
+            _logger.LogInformation("\nSelect a backup to perform:");
+            for (int i = 0; i < _configuration.Backups.Count; i++)
+            {
+                var backupInt = _configuration.Backups[i];
+                _logger.LogInformation($"{i + 1}. Backup Name: {backupInt.Name}, Bar code {(string.IsNullOrEmpty(backupInt.Barcode) ? "None" : backupInt.Barcode)}, Source: {backupInt.Source}, Destination: {backupInt.Destination}");
+            }
 
-    var paddedDescriptorData = PaddingUtility.AddPadding(encryptedDescriptorData, (int)descriptor.BlockSize);
+            Console.Write("Enter your choice (or '0' to go back): ");
+            var choice = Console.ReadLine();
 
-    const ulong fileMarkBlocks = 2;
- 
-    var descriptorSize = paddedDescriptorData.Length;
-    var descriptorSizeBlocks = Math.Ceiling((double)descriptorSize / descriptor.BlockSize);
+            if (choice == "0")
+            {
+                return;
+            }
 
-    var totalBlocks = fileMarkBlocks + descriptorSizeBlocks;
+            if (!int.TryParse(choice, out int index) || index < 1 || index > _configuration.Backups.Count)
+            {
+                _logger.LogInformation("Invalid choice. Please try again.");
+                continue;
+            }
 
-    var maxBlocks = LTOBlockSizes.GetMaxBlocks(ltoGen);
-    if (totalBlocks > maxBlocks) {
-      _logger.LogInformation("Backup will not fit on tape. Please use a larger tape.");
-      return 1;
+            var backup = _configuration.Backups[index - 1];
+
+            uint blockSize = LTOBlockSizes.GetBlockSize(backup.LTOGen);
+
+            // Step 1: Create Descriptor and Write to File System
+            CreateDescriptor(backup.Source, _descriptorFilePath, blockSize);
+
+            // Step 2: calculate if files in descriptor will fit on tape
+            var checkMediaSizeResult = CheckMediaSize(backup.LTOGen);
+            if (checkMediaSizeResult != 0)
+                return;
+
+            // Step 3: Write Files to Tape
+            WriteFilesToTape(backup.Source, _descriptorFilePath, blockSize);
+
+            File.Delete(_descriptorFilePath);
+            _logger.LogInformation("Backup completed.");
+            return;
+        }
     }
-    else {
-      _logger.LogInformation("Backup will fit on tape.");
+
+    private void Restore()
+    {
+        while (true)
+        {
+            _logger.LogInformation("\nSelect a backup to restore:");
+            for (int i = 0; i < _configuration.Backups.Count; i++)
+            {
+                var backupInt = _configuration.Backups[i];
+                _logger.LogInformation($"{i + 1}. Backup Name: {backupInt.Name}, Bar code {(string.IsNullOrEmpty(backupInt.Barcode) ? "None" : backupInt.Barcode)}, Source: {backupInt.Source}, Destination: {backupInt.Destination}");
+            }
+
+            Console.Write("Enter your choice (or '0' to go back): ");
+            var choice = Console.ReadLine();
+
+            if (choice == "0")
+            {
+                return;
+            }
+
+            if (!int.TryParse(choice, out int index) || index < 1 || index > _configuration.Backups.Count)
+            {
+                _logger.LogInformation("Invalid choice. Please try again.");
+                continue;
+            }
+
+            var backup = _configuration.Backups[index - 1];
+
+            uint blockSize = LTOBlockSizes.GetBlockSize(backup.LTOGen);
+
+            // Step 1: Find Descriptor on Tape
+            var descriptor = FindDescriptor(blockSize);
+            if (descriptor != null)
+            {
+                var json = JsonSerializer.Serialize(descriptor, new JsonSerializerOptions { WriteIndented = true });
+                _logger.LogInformation(json);
+            }
+
+            if (descriptor == null)
+            {
+                _logger.LogInformation("Descriptor not found on tape.");
+                return;
+            }
+
+            // Step 2: Restore Files to Directory
+            RestoreDirectory(descriptor, backup.Destination);
+            _logger.LogInformation("Restore completed.");
+            return;
+        }
     }
 
-    return 0;
-  }
+    private void ReadCartrigeMemory()
+    {
+        try
+        {
+            using var tapeHandler = new TapeDeviceHandler(_tapeDeviceLogger, @"\\.\Tape0");
+            if (tapeHandler.ltoCartridgeMemory != null)
+            {
+                tapeHandler.ltoCartridgeMemory.ReadCartridgeAttributes();
 
-  private void Backup() {
-    while (true) {
-      _logger.LogInformation("\nSelect a backup to perform:");
-      for (int i = 0; i < _configuration.Backups.Count; i++) {
-        var backupInt = _configuration.Backups[i];
-        _logger.LogInformation($"{i + 1}. Backup Name: {backupInt.Name}, Bar code {(string.IsNullOrEmpty(backupInt.Barcode) ? "None" : backupInt.Barcode)}, Source: {backupInt.Source}, Destination: {backupInt.Destination}");
-      }
-
-      Console.Write("Enter your choice (or '0' to go back): ");
-      var choice = Console.ReadLine();
-
-      if (choice == "0") {
-        return;
-      }
-
-      if (!int.TryParse(choice, out int index) || index < 1 || index > _configuration.Backups.Count) {
-        _logger.LogInformation("Invalid choice. Please try again.");
-        continue;
-      }
-
-      var backup = _configuration.Backups[index - 1];
-
-      uint blockSize = LTOBlockSizes.GetBlockSize(backup.LTOGen);
-
-      // Step 1: Create Descriptor and Write to File System
-      CreateDescriptor(backup.Source, _descriptorFilePath, blockSize);
-
-      // Step 2: calculate if files in descriptor will fit on tape
-      var checkMediaSizeResult = CheckMediaSize(backup.LTOGen);
-      if (checkMediaSizeResult != 0)
-        return;
-
-      // Step 3: Write Files to Tape
-      WriteFilesToTape(backup.Source, _descriptorFilePath, blockSize);
-
-      File.Delete(_descriptorFilePath);
-      _logger.LogInformation("Backup completed.");
-      return;
+                foreach (var attr in tapeHandler.ltoCartridgeMemory.Attributes)
+                {
+                    Console.WriteLine($"(0x{attr.Address:X4}): {attr.Name}: {attr.GetValueAsString()}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Error: " + ex.Message);
+        }
     }
-  }
+    private void WriteCartrigeMemory()
+    {
+        string aValue = "Test"; // Example value to write
+        try
+        {
+            using var tapeHandler = new TapeDeviceHandler(_tapeDeviceLogger, @"\\.\Tape0");
+            if (tapeHandler.ltoCartridgeMemory != null)
+            {            
+                LTOCmAttribute aAttibute = new LTOCmAttribute();
 
-  private void Restore() {
-    while (true) {
-      _logger.LogInformation("\nSelect a backup to restore:");
-      for (int i = 0; i < _configuration.Backups.Count; i++) {
-        var backupInt = _configuration.Backups[i];
-        _logger.LogInformation($"{i + 1}. Backup Name: {backupInt.Name}, Bar code {(string.IsNullOrEmpty(backupInt.Barcode) ? "None" : backupInt.Barcode)}, Source: {backupInt.Source}, Destination: {backupInt.Destination}");
-      }
+                aAttibute.Address = 0x0800;
+                aAttibute.Format = LTOCmAttributeFormat.ASCII;
+                aAttibute.Length = 8;
+                aAttibute.Value = new byte[aAttibute.Length];
+                byte[] buffer = Encoding.ASCII.GetBytes(aValue);
+                Array.Copy(buffer, 0, aAttibute.Value, 0, buffer.Length);
 
-      Console.Write("Enter your choice (or '0' to go back): ");
-      var choice = Console.ReadLine();
-
-      if (choice == "0") {
-        return;
-      }
-
-      if (!int.TryParse(choice, out int index) || index < 1 || index > _configuration.Backups.Count) {
-        _logger.LogInformation("Invalid choice. Please try again.");
-        continue;
-      }
-
-      var backup = _configuration.Backups[index - 1];
-      
-      uint blockSize = LTOBlockSizes.GetBlockSize(backup.LTOGen);
-
-      // Step 1: Find Descriptor on Tape
-      var descriptor = FindDescriptor(blockSize);
-      if (descriptor != null) {
-        var json = JsonSerializer.Serialize(descriptor, new JsonSerializerOptions { WriteIndented = true });
-        _logger.LogInformation(json);
-      }
-
-      if (descriptor == null) {
-        _logger.LogInformation("Descriptor not found on tape.");
-        return;
-      }
-
-      // Step 2: Restore Files to Directory
-      RestoreDirectory(descriptor, backup.Destination);
-      _logger.LogInformation("Restore completed.");
-      return;
+                tapeHandler.ltoCartridgeMemory.WriteCartridgeAttribute(aAttibute);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Error: " + ex.Message);
+        }
     }
-  }
 }

--- a/src/MaksIT.LTO.Core/MassStorage/LTOCmAttribute.cs
+++ b/src/MaksIT.LTO.Core/MassStorage/LTOCmAttribute.cs
@@ -1,0 +1,118 @@
+﻿using System.Text;
+
+namespace MaksIT.LTO.Core.MassStorage
+{
+
+    public enum LTOCmAttributeFormat
+    {
+        Unknown,
+        Binary,
+        ASCII,
+        Text
+    }
+
+    public class LTOCmAttribute
+    {
+        public ushort Address { get; set; }
+        public string? Name { get; set; }
+        public bool Writable { get; set; }
+        public LTOCmAttributeFormat Format { get; set; }
+        public int Length { get; set; }
+        public byte[]? Value { get; set; }
+        
+        public string GetValueAsString()
+        {
+            switch (Format)
+            {
+                case LTOCmAttributeFormat.Binary:
+                    {
+                        if (Value == null || Value.Length == 0 || Value.Length > 8)
+                            throw new ArgumentException("Byte array must be between 1 and 8 bytes.");
+
+                        byte[] tempbuffer = new byte[Value.Length];
+                        Array.Copy(Value, 0, tempbuffer, 0, Value.Length);
+
+                        if (BitConverter.IsLittleEndian)
+                            Array.Reverse(tempbuffer);
+
+                        Int64 result = 0;
+                        for (int i = 0; i < tempbuffer.Length; i++)
+                        {
+                            result *= 256;
+                            result += (tempbuffer[i]);
+                        }
+
+                        return result.ToString(); // + ' ' + BitConverter.ToString(Value);                        
+                    }
+                case LTOCmAttributeFormat.ASCII:
+                    return Encoding.ASCII.GetString(Value).TrimEnd('\0');
+                case LTOCmAttributeFormat.Text:
+                    return Encoding.UTF8.GetString(Value).TrimEnd('\0');
+                case LTOCmAttributeFormat.Unknown:
+                    return BitConverter.ToString(Value);
+                default:
+                    return BitConverter.ToString(Value);
+            }
+        }
+    }
+
+    public static class LTOCmKnownAttributes
+    {
+        private static readonly List<LTOCmAttribute> KnownAttributes = new()
+        {
+            new() { Address = 0x0000, Name = "Remaining capacity in partition [MiB]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0001, Name = "Maximum capacity in partition [MiB]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0002, Name = "TapeAlert flags", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0003, Name = "Load count", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0004, Name = "MAM space remaining [B]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0005, Name = "Assigning organization", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0006, Name = "Format density code", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 1 },
+            new() { Address = 0x0007, Name = "Initialization count", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 2 },
+            new() { Address = 0x0008, Name = "Volume identifier", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 32 },
+            new() { Address = 0x0009, Name = "Volume change reference", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 4 },
+            new() { Address = 0x020a, Name = "Density vendor/serial number at last load", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 40 },
+            new() { Address = 0x020b, Name = "Density vendor/serial number at load-1", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 40 },
+            new() { Address = 0x020c, Name = "Density vendor/serial number at load-2", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 40 },
+            new() { Address = 0x020d, Name = "Density vendor/serial number at load-3", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 40 },
+            new() { Address = 0x0220, Name = "Total MiB written in medium life", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0221, Name = "Total MiB read in medium life", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0222, Name = "Total MiB written in current/last load", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0223, Name = "Total MiB read in current/last load", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0224, Name = "Logical position of first encrypted block", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0225, Name = "Logical position of first unencrypted block after first encrypted block", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0340, Name = "Medium usage history", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 90 },
+            new() { Address = 0x0341, Name = "Partition usage history", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 60 },
+            new() { Address = 0x0400, Name = "Medium manufacturer", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0401, Name = "Medium serial number", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 32 },
+            new() { Address = 0x0402, Name = "Medium length [m]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 4 },
+            new() { Address = 0x0403, Name = "Medium width [0.1 mm]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 4 },
+            new() { Address = 0x0404, Name = "Assigning organization", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0405, Name = "Medium density code", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 1 },
+            new() { Address = 0x0406, Name = "Medium manufacture date", Writable = false, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0407, Name = "MAM capacity [B]", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 8 },
+            new() { Address = 0x0408, Name = "Medium type", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 1 },
+            new() { Address = 0x0409, Name = "Medium type information", Writable = false, Format = LTOCmAttributeFormat.Binary, Length = 2 },
+            new() { Address = 0x040a, Name = "Numeric medium serial number", Writable = false, Format = LTOCmAttributeFormat.Unknown, Length = -1 },
+            new() { Address = 0x0800, Name = "Application vendor", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0801, Name = "Application name", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 32 },
+            new() { Address = 0x0802, Name = "Application version", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 8 },
+            new() { Address = 0x0803, Name = "User medium text label", Writable = true, Format = LTOCmAttributeFormat.Text, Length = 160 },
+            new() { Address = 0x0804, Name = "Date and time last written", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 12 },
+            new() { Address = 0x0805, Name = "Text localization identifier", Writable = true, Format = LTOCmAttributeFormat.Binary, Length = 1 },
+            new() { Address = 0x0806, Name = "Barcode", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 32 },
+            new() { Address = 0x0807, Name = "Owning host textual name", Writable = true, Format = LTOCmAttributeFormat.Text, Length = 80 },
+            new() { Address = 0x0808, Name = "Media pool", Writable = true, Format = LTOCmAttributeFormat.Text, Length = 160 },
+            new() { Address = 0x0809, Name = "Partition user text label", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 16 },
+            new() { Address = 0x080a, Name = "Load/unload at partition", Writable = true, Format = LTOCmAttributeFormat.Binary, Length = 1 },
+            new() { Address = 0x080b, Name = "Application format version", Writable = true, Format = LTOCmAttributeFormat.ASCII, Length = 16 },
+            new() { Address = 0x080c, Name = "Volume coherency information", Writable = true, Format = LTOCmAttributeFormat.Unknown, Length = -1 },
+            new() { Address = 0x0820, Name = "Medium globally unique identifier", Writable = true, Format = LTOCmAttributeFormat.Binary, Length = 36 },
+            new() { Address = 0x0821, Name = "Media pool globally unique identifier", Writable = true, Format = LTOCmAttributeFormat.Binary, Length = 36 }
+        };
+
+        public static LTOCmAttribute? GetAttributeByAddress(ushort address)
+        {
+            return KnownAttributes.Find(a => a.Address == address);
+        }        
+    }
+}

--- a/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandler.cs
+++ b/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandler.cs
@@ -14,11 +14,14 @@ public partial class TapeDeviceHandler : IDisposable {
   private string _tapeDevicePath;
   private SafeFileHandle _tapeHandle;
 
+  public LTOCartridgeMemory? ltoCartridgeMemory;
+
   private const uint GENERIC_READ = 0x80000000;
   private const uint GENERIC_WRITE = 0x40000000;
   private const uint OPEN_EXISTING = 3;
 
   // Define IOCTL base
+  private const uint FILE_DEVICE_CONTROLLER = 0x00000004;
   private const uint FILE_DEVICE_TAPE = 0x0000001F;
   private const uint FILE_DEVICE_MASS_STORAGE = 0x0000002D;
 
@@ -75,7 +78,8 @@ public partial class TapeDeviceHandler : IDisposable {
     _logger = logger;
     _tapeDevicePath = tapeDevicePath;
     OpenTapeDevice(GENERIC_READ | GENERIC_WRITE);
-  }
+    ltoCartridgeMemory = new LTOCartridgeMemory(this);
+    }
 
   [MemberNotNull(nameof(_tapeHandle))]
   private void OpenTapeDevice(uint desiredAccess) {

--- a/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandlerMAM.cs
+++ b/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandlerMAM.cs
@@ -1,0 +1,264 @@
+﻿using MaksIT.LTO.Core.MassStorage;
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace MaksIT.LTO.Core;
+
+public partial class TapeDeviceHandler : IDisposable
+{
+
+    #region LTO-CM Structures from IBM Documentation
+
+
+    public class LTOCartridgeMemory
+    {
+        private uint MaxBufferSize = 32736; // Maximum buffer size for SCSI commands
+
+        private TapeDeviceHandler parent;
+
+        public List<LTOCmAttribute> Attributes;
+
+        public LTOCartridgeMemory(TapeDeviceHandler parentInstance)
+        {
+            this.parent = parentInstance;
+            Attributes = new List<LTOCmAttribute>();
+        }
+
+        public void ReadCartridgeAttributes()
+        {
+            IntPtr ptrIn = IntPtr.Zero;
+
+            byte[] buffer = new byte[MaxBufferSize];
+            GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            SCSI_PASS_THROUGH_DIRECT spt = new SCSI_PASS_THROUGH_DIRECT();
+
+            spt.DataIn = 1; // Data transfer direction: IN
+            spt.TimeOutValue = 60;
+            spt.CdbLength = 16; // CDB length for READ ATTRIBUTE command
+            spt.Cdb = new byte[spt.CdbLength];
+            spt.Cdb[0] = 0x8C; // READ ATTRIBUTE command code
+            spt.Cdb[1] = 0x00; // Service Action Sub-command code 
+            spt.Cdb[2] = 0x00; // Obsolete
+            spt.Cdb[3] = 0x00; // Obsolete
+            spt.Cdb[4] = 0x00; // Obsolete
+            spt.Cdb[5] = 0x00; // Logical Volume number
+            spt.Cdb[6] = 0x00; // Reserved
+            spt.Cdb[7] = 0x00; // Partition Number
+
+            spt.Cdb[8] = 0x00; // First attribute identifier (MSB)
+            spt.Cdb[9] = 0x00; // First attribute identifier (LSB)  
+
+            // Isnt Allocation Length size, 4 Bytes?
+            spt.Cdb[10] = 0x02; // Allocation Length (MSB)
+            spt.Cdb[11] = 0x00; // Allocation Length (LSB)
+            spt.Cdb[12] = 0x00; // Reserved
+            spt.Cdb[13] = 0x00; // Reserved
+
+
+            spt.Cdb[14] = 0x00; // Cache bit. 1 if no medium is mounted, 0 do not use cache, require live medium access
+            spt.Cdb[15] = 0x00; // Should be optional
+            spt.Length = (ushort)Marshal.SizeOf(typeof(SCSI_PASS_THROUGH_DIRECT));
+
+            //Is this Correct?
+            spt.DataTransferLength = (uint)buffer.Length;
+            spt.DataBuffer = dataHandle.AddrOfPinnedObject();
+
+            ptrIn = Marshal.AllocHGlobal(Marshal.SizeOf(spt));
+            Marshal.StructureToPtr(spt, ptrIn, true);
+
+            bool result = DeviceIoControl(
+                parent._tapeHandle,
+                IOCTL_SCSI_PASS_THROUGH_DIRECT,
+                ptrIn,
+                (uint)Marshal.SizeOf(spt),
+                ptrIn,
+                (uint)Marshal.SizeOf(spt),
+                out var iBytesReturned,
+                IntPtr.Zero);
+
+            if (!result)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "SCSI READ ATTRIBUTE failed");
+
+            SCSI_PASS_THROUGH_DIRECT retorno = (SCSI_PASS_THROUGH_DIRECT)Marshal.PtrToStructure(ptrIn, typeof(SCSI_PASS_THROUGH_DIRECT));
+
+            dataHandle.Free();
+            ParseAttributes(buffer);
+        }
+                
+        private void ParseAttributes(byte[] buffer)
+        {
+            // If the system architecture is little-endian (that is, little end first),
+            // reverse the byte array.
+            byte[] tempbuffer = new byte[4];    // Table 72 — READ ATTRIBUTE: AVAILABLE DATA (n-3)
+            Array.Copy(buffer, 0, tempbuffer, 0, 4);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(tempbuffer);
+            int avaiableData = BitConverter.ToInt32(tempbuffer, 0);  // representes the number of bytes of Attributes available in the buffer
+            Console.WriteLine($"Numer of Bytes of Attributes returned: {avaiableData}");
+
+            byte[] attributeBuffer = new byte[avaiableData];
+
+            Array.Copy(buffer, 4, attributeBuffer, 0, avaiableData);
+
+            
+            Attributes.Clear();
+            int offset = 0;
+            int attributeHeader = 5; // Each attribute starts with 5 bytes: 2 for ID, 1 for type, 2 for length
+
+            while (offset < attributeBuffer.Length)
+            {
+                ushort attrId = (ushort)((attributeBuffer[offset] << 8) | attributeBuffer[offset + 1]);
+                ushort type = (ushort)((attributeBuffer[offset + 2]));
+                ushort length = (ushort)((attributeBuffer[offset + 3] << 8) | attributeBuffer[offset + 4]);
+
+                if (offset + attributeHeader + length > attributeBuffer.Length)
+                    break;
+
+                byte[] value = new byte[length];
+                Array.Copy(attributeBuffer, offset + attributeHeader, value, 0, length);
+
+                var KnownAttr = LTOCmKnownAttributes.GetAttributeByAddress(attrId);
+                
+                if (KnownAttr == null)
+                {
+                    KnownAttr = new LTOCmAttribute
+                    {
+                        Name = $"Unknown (0x{attrId:X4})",
+                        Writable = false,
+                        Format = LTOCmAttributeFormat.Unknown,
+                        Length = -1
+                    };
+                };                
+
+
+                KnownAttr.Address = attrId;
+                KnownAttr.Value = new byte[length];
+                Array.Copy(attributeBuffer, offset + attributeHeader, KnownAttr.Value, 0, length);
+
+                if ((KnownAttr.Length != length) && (KnownAttr.Format != LTOCmAttributeFormat.Unknown))
+                {
+                    throw new ArgumentException($"Expected length is diferent from Length saved on the Dictionary. {attrId}: {KnownAttr.Length} - {length}");
+                }
+
+                Attributes.Add(KnownAttr);
+
+                offset += length + attributeHeader;
+            }
+            Attributes.Sort((x, y) => x.Address.CompareTo(y.Address));            
+        }
+
+
+        public void WriteCartridgeAttribute(LTOCmAttribute aAttibute)
+        {
+            var KnownAttr = LTOCmKnownAttributes.GetAttributeByAddress(aAttibute.Address);
+            if (KnownAttr == null)
+            {
+                throw new ArgumentException($"Unknown Attribute!");
+            };
+
+            if (!KnownAttr.Writable)
+            {
+                throw new ArgumentException($"Attribute {KnownAttr.Name} is not writable!");
+            };
+
+            if (aAttibute.Value == null)
+            {
+                throw new ArgumentException($"Attribute Value can't be null!");
+            };
+
+
+            IntPtr ptrIn = IntPtr.Zero;
+
+            // We should construct the buffer with the attribute data
+            byte[] buffer = new byte[MaxBufferSize];
+                        
+            // definir o tamanho total de bytes da mensagem
+            buffer[0] = 0x00; // Parameter Data Leght MSB
+            buffer[1] = 0x00; // Parameter Data Leght
+            buffer[2] = 0x00; // Parameter Data Leght
+            buffer[3] = 0x00; // Parameter Data Leght LSB
+
+                        
+            buffer[4] = (byte)(aAttibute.Address >> 8); // Attribute Identifier LSB
+            buffer[5] = (byte)(aAttibute.Address & 0xFF); // Attribute Identifier LSB
+
+            buffer[6] = 0x00; // Attribute READ ONLY (0x8 for Readonly, 0x0 read/write)
+
+            switch (aAttibute.Format)
+            {
+                case LTOCmAttributeFormat.Binary:
+                    buffer[7] = 0x00; // Attribute Type (0x00 for binary, 0x01 for ASCII, 0x10 for ASCII)
+                    break;
+                case LTOCmAttributeFormat.ASCII:
+                    buffer[7] = 0x01; // Attribute Type (0x00 for binary, 0x01 for ASCII, 0x10 for ASCII)
+                    break;
+                case LTOCmAttributeFormat.Text:
+                    buffer[7] = 0x10; // Attribute Type (0x00 for binary, 0x01 for ASCII, 0x10 for ASCII)
+                    break;
+                default:
+                    throw new ArgumentException("Unknown attribute format");
+            }            
+            
+            buffer[8] = (byte)(aAttibute.Length >> 8); // Attribute Length MSB
+            buffer[9] = (byte)(aAttibute.Length & 0xFF); // Attribute Length LSB
+
+            Array.Copy(aAttibute.Value,0,buffer,10, aAttibute.Length);
+
+
+            GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            SCSI_PASS_THROUGH_DIRECT spt = new SCSI_PASS_THROUGH_DIRECT();
+
+            spt.DataIn = 0; // Data transfer direction: OUT
+            spt.TimeOutValue = 60;
+            spt.CdbLength = 16; // CDB length for READ ATTRIBUTE command
+            spt.Cdb = new byte[spt.CdbLength];
+            spt.Cdb[0] = 0x8D; // WRITE ATTRIBUTE command code
+            spt.Cdb[1] = 0x01; // Write-through cache off
+            spt.Cdb[2] = 0x00; // Obsolete
+            spt.Cdb[3] = 0x00; // Obsolete
+            spt.Cdb[4] = 0x00; // Obsolete
+            spt.Cdb[5] = 0x00; // Logical Volume number
+            spt.Cdb[6] = 0x00; // Reserved
+            spt.Cdb[7] = 0x00; // Partition Number
+
+            spt.Cdb[8] = 0x00; // Reserved
+            spt.Cdb[9] = 0x00; // Reserved  
+
+            //// Isnt Allocation Length size, 4 Bytes?
+            spt.Cdb[10] = 0x00; // PARAMETER LIST LENGTH (MSB)
+            spt.Cdb[11] = 0x00; // PARAMETER LIST LENGTH
+            spt.Cdb[12] = 0x00; // PARAMETER LIST LENGTH
+            spt.Cdb[13] = 0x01; // PARAMETER LIST LENGTH (LSB)
+
+            spt.Cdb[14] = 0x00; // Reserved
+            spt.Cdb[15] = 0x00; // Control Byte should be zero
+            spt.Length = (ushort)Marshal.SizeOf(typeof(SCSI_PASS_THROUGH_DIRECT));
+
+            //Is this Correct?
+            spt.DataTransferLength = (uint)buffer.Length;
+            spt.DataBuffer = dataHandle.AddrOfPinnedObject();
+
+            ptrIn = Marshal.AllocHGlobal(Marshal.SizeOf(spt));
+            Marshal.StructureToPtr(spt, ptrIn, true);
+
+            bool result = DeviceIoControl(
+                parent._tapeHandle,
+                IOCTL_SCSI_PASS_THROUGH_DIRECT,
+                ptrIn,
+                (uint)Marshal.SizeOf(spt),
+                ptrIn,
+                (uint)Marshal.SizeOf(spt),
+                out var iBytesReturned,
+                IntPtr.Zero);
+
+            if (!result)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "SCSI READ ATTRIBUTE failed");
+
+            dataHandle.Free();
+        }
+    }
+}
+#endregion

--- a/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandlerNtddscsi.cs
+++ b/src/MaksIT.LTO.Core/MassStorage/TapeDeviceHandlerNtddscsi.cs
@@ -1,0 +1,58 @@
+using System.Runtime.InteropServices;
+
+namespace MaksIT.LTO.Core;
+
+// Preparing this file to be able to talk to tape devices using the SCSI interface.
+// Sending correct SCSI commands to tape devices will retrieve the LTO-CM Ship Content.
+// It is also possible to write to the LTO-CM.
+// Check the IBM pdf for instructions.
+//      5.2.16 READ ATTRIBUTE - 8Ch
+//      5.5 Medium auxiliary memory attributes (MAM).
+
+
+public partial class TapeDeviceHandler : IDisposable {
+
+    #region Tape IOCTL Commands from ntddscsi.h
+
+    private const uint IOCTL_SCSI_BASE = FILE_DEVICE_CONTROLLER;
+    private const uint IOCTL_SCSI_PASS_THROUGH = (IOCTL_SCSI_BASE << 16) | ((FILE_READ_ACCESS | FILE_WRITE_ACCESS) << 14) | (0x0401 << 2) | METHOD_BUFFERED;
+    private const uint IOCTL_SCSI_PASS_THROUGH_DIRECT = (IOCTL_SCSI_BASE << 16) | ((FILE_READ_ACCESS | FILE_WRITE_ACCESS) << 14) | (0x0405 << 2) | METHOD_BUFFERED;
+
+    #endregion
+
+    #region Tape IOCTL Structures from ntddscsi.h
+
+    // IA Make the following structures so we need to test.
+
+    // This structure is used for SCSI commands
+    // It is used to send commands to the tape device.
+    // It contains the command descriptor block (CDB) and other parameters.
+    // It is used with the IOCTL_SCSI_PASS_THROUGH and IOCTL_SCSI_PASS_THROUGH_DIRECT control codes.
+    //
+    
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SCSI_PASS_THROUGH_DIRECT
+    {
+        public ushort Length;
+        public byte ScsiStatus;
+        public byte PathId;
+        public byte TargetId;
+        public byte Lun;
+        public byte CdbLength;
+        public byte SenseInfoLength;
+        public byte DataIn;
+        public uint DataTransferLength;
+        public uint TimeOutValue;
+        public IntPtr DataBuffer;
+        public uint SenseInfoOffset;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] Cdb;
+    }
+
+    #endregion
+
+    #region Tape IOCTL Methods from ntddscsi.h
+
+
+    #endregion
+}


### PR DESCRIPTION
I added the following:

LTOCmAttribute.cs
    Defines structures of the MAM Attributes;
    Defines a list of known Attributes.

TapeDeviceHandlerNtddscsi.cs
    Defines the structures to call the pinvoke deviceIOCommand 

TapeDeviceHandlerMAM.cs
    Implements LTOCartridgeMemory class, that can retrieve all attributes from the tape, and write an Attribute to the tape.

I also eddited the Application.cs to call the new methods.